### PR TITLE
Utest2

### DIFF
--- a/envi/archs/arm/__init__.py
+++ b/envi/archs/arm/__init__.py
@@ -8,8 +8,6 @@ from envi.archs.arm.regs import *
 from envi.archs.arm.disasm import *
 
 class ArmModule(envi.ArchitectureModule):
-    #Current ARM version working in - Not fully integrated yet
-    archVersion = ('ARMv7A')
 
     def __init__(self, name='ARMv7A'):
         self.archVersion = name
@@ -52,8 +50,6 @@ class ThumbModule(envi.ArchitectureModule):
     '''
     This architecture module will *not* shift to ARM mode.  Evar.
     '''
-    #Current ARM version working in - Not fully integrated yet
-    archVersion = ('ARMv7A')
 
     def __init__(self, name='ARMv7A'):
         self.archVersion = name

--- a/envi/archs/arm/__init__.py
+++ b/envi/archs/arm/__init__.py
@@ -51,7 +51,7 @@ class ThumbModule(envi.ArchitectureModule):
     This architecture module will *not* shift to ARM mode.  Evar.
     '''
 
-    def __init__(self, name='ARMv7'):
+    def __init__(self, name='ARMv7A'):
         import envi.archs.thumb16.disasm as eatd
         envi.ArchitectureModule.__init__(self, name, maxinst=4)
         self._arch_reg = self.archGetRegCtx()

--- a/envi/archs/arm/__init__.py
+++ b/envi/archs/arm/__init__.py
@@ -10,11 +10,11 @@ from envi.archs.arm.disasm import *
 class ArmModule(envi.ArchitectureModule):
 
     def __init__(self, name='ARMv7A'):
-        self.archVersion = name
         import envi.archs.thumb16.disasm as eatd
         envi.ArchitectureModule.__init__(self, name, maxinst=4)
         self._arch_reg = self.archGetRegCtx()
         self._arch_dis = ArmDisasm()
+        self._arch_dis.setArchMask(name)
         self._arch_thumb_dis = eatd.ThumbDisasm()
 
     def archGetRegCtx(self):
@@ -51,13 +51,13 @@ class ThumbModule(envi.ArchitectureModule):
     This architecture module will *not* shift to ARM mode.  Evar.
     '''
 
-    def __init__(self, name='ARMv7A'):
-        self.archVersion = name
+    def __init__(self, name='ARMv7'):
         import envi.archs.thumb16.disasm as eatd
         envi.ArchitectureModule.__init__(self, name, maxinst=4)
         self._arch_reg = self.archGetRegCtx()
         self._arch_dis = eatd.ThumbDisasm(doModeSwitch=False)
-
+        #armVersion mask should be set here if needed
+        
     def archGetRegCtx(self):
         return ArmRegisterContext()
 

--- a/envi/archs/arm/const.py
+++ b/envi/archs/arm/const.py
@@ -148,7 +148,7 @@ COND_LT:"lt", # Signed less than N set and V clear, or N clear and V set (N!= V)
 COND_GT:"gt", # Signed greater than Z clear, and either N set and V set, or N clear and V clear (Z == 0,N == V) 
 COND_LE:"le", # Signed less than or equal Z set, or N set and V clear, or N clear and V set (Z == 1 or N!= V) 
 COND_AL:"", # Always (unconditional) - could be "al" but "" seems better...
-COND_EXTENDED:"2", # See extended opcode table
+COND_EXTENDED:"", # See extended opcode table
 }
 cond_map = {
 COND_EQ:0,      # Equal Z set 

--- a/envi/archs/arm/const.py
+++ b/envi/archs/arm/const.py
@@ -31,6 +31,13 @@ REV_ALL_ARMv6  = (REV_ARMv6 | REV_ARMv6T2 | REV_ARMv6M)
 REV_ALL_ARMv7  = (REV_ARMv7A | REV_ARMv7R | REV_ARMv7M | REV_ARMv7EM) 
 REV_ALL_ARMv8  = (REV_ARMv8A | REV_ARMv8R | REV_ARMv8M)
 
+#Todo - For easy instruction filtering add more like:
+REV_ALL_TO_ARMv6 = REV_ALL_ARMv4 | REV_ALL_ARMv5 | REV_ALL_ARMv6
+REV_ALL_FROM_ARMv6 = REV_ALL_ARMv6 | REV_ALL_ARMv7 | REV_ALL_ARMv8
+#Note: since arm must be backwards compatible any depreciated commands
+#Would be noted but not removed with the REV_ALL_TO_* if this is even used.
+#These are put here for suggestion and comment for now
+
 REV_ALL_ARM = (REV_ALL_ARMv4 | REV_ALL_ARMv5 | REV_ALL_ARMv6 | REV_ALL_ARMv7 | REV_ALL_ARMv8)
 
 #Will be set below, THUMB16 up through v6 except v6T2, THUMB2 from v6T2 up, THUMBEE from v7 up.

--- a/envi/archs/arm/disasm.py
+++ b/envi/archs/arm/disasm.py
@@ -2615,14 +2615,14 @@ class ArmDisasm:
         
 
     def setArchVersion(key = 'ARMv7A'):
-    ''' set arch versions '''
+        ''' set arch versions '''
         archVersion = key
         archVersionMask = ARCH_REVS[key]
 
-    def getArchMask()
+    def getArchMask():
         return _archVersionMask
 
-    def getArchVersion()
+    def getArchVersion():
         return _archVersion
     
     def setEndian(self, endian):

--- a/envi/archs/arm/disasm.py
+++ b/envi/archs/arm/disasm.py
@@ -2140,18 +2140,22 @@ class ArmImmOffsetOper(ArmOperand):
         # there are certain circumstances where we can survive without an emulator
         pubwl = self.pubwl >> 3
         u = pubwl & 1
+        tsize = self.tsize # to help cope with ldcl
         # if we don't have an emulator, we must be PC-based since we know it
         if self.base_reg == REG_PC:
             base = self.va
+            #to handle lcdl. Override tsize to return proper address
+            if ((self.pubwl >>2) & 1) == 1:
+                tsize =4
         elif emu == None:
             return None
         else:
             base = emu.getRegister(self.base_reg)
 
         if u:
-            addr = (base + self.offset) & e_bits.u_maxes[self.tsize]
+            addr = (base + self.offset) & e_bits.u_maxes[tsize]
         else:
-            addr = (base - self.offset) & e_bits.u_maxes[self.tsize]
+            addr = (base - self.offset) & e_bits.u_maxes[tsize]
 
         
         if (self.pubwl & 0x12) == 0x12:    # pre-indexed
@@ -2191,6 +2195,7 @@ class ArmImmOffsetOper(ArmOperand):
                     mcanv.addNameText("0x%x" % value)
 
             # FIXME: is there any chance of us doing indexing on PC?!?
+            # ldcl literal trips this in some cases - leaving for now
             if idxing != 0x10:
                 print "OMJ! indexing on the program counter!"
         else:
@@ -2220,6 +2225,7 @@ class ArmImmOffsetOper(ArmOperand):
             addr = self.getOperAddr(op)    # only works without an emulator because we've already verified base_reg is PC
             tname = "[#0x%x]" % addr
             # FIXME: is there any chance of us doing indexing on PC?!?
+            # ldcl literal trips this in some cases - leaving for now - to check for other instances
             if idxing != 0x10:
                 print "OMJ! indexing on the program counter!"
         else:

--- a/envi/archs/arm/disasm.py
+++ b/envi/archs/arm/disasm.py
@@ -170,11 +170,24 @@ dp_mnem = ("and","eor","sub","rsb","add","adc","sbc","rsc","tst","teq","cmp","cm
 #bic = v4, v5t, v6, v7
 #bkpt = v5t, v6, v7
 #bl = v4, v5t, v6, v7
-#blx = v5t, v6, v7
+#blx = v4, v5t, v6, v7
+#blx(2) = v5t, v6, v7
 #bx = v4T, v5t, v6, v7
 #bxj = v5tej, v6, v7
 #cdp = v4, v5t, v6, v7
 #cdp2 = v5t, v6, v7
+#clrex = v6k, v7
+#clz = v5t, v6, v7
+#cmn =  v4, v5t, v6, v7
+#cmp =  v4, v5t, v6, v7
+#dbg = v7 (nop in v6t2)
+#dmb = v7
+#dsb = v7
+#eor =  v4, v5t, v6, v7
+#isb = v7
+#ldc = v4, v5t, v6, v7
+#ldc2 = v5t, v6, v7
+
 
 # FIXME: THIS IS FUGLY but sadly it works
 dp_noRn = (13,15)
@@ -1122,7 +1135,7 @@ def p_coproc_dp(opval, va):
     
     opcode = (IENC_COPROC_DP << 16)
     return (opcode, mnem, olist, 0)       #FIXME: CDP2 (cond = 0b1111) also needs handling.
-
+                                          # 6/22/16 CDP2 decodes properly. Is this still needed?
 mcr_mnem = ("mcr", "mrc")
 def p_coproc_reg_xfer(opval, va):
     opcode1 = (opval>>21) & 0x7

--- a/envi/archs/arm/disasm.py
+++ b/envi/archs/arm/disasm.py
@@ -2150,11 +2150,11 @@ class ArmImmOffsetOper(ArmOperand):
 
         
         if (self.pubwl & 0x12) == 0x12:    # pre-indexed
-            if emu._forrealz: emu.setRegister( self.base_reg, addr)
+            if (emu != None) and (emu._forrealz): emu.setRegister( self.base_reg, addr)
             return addr
 
         elif (self.pubwl & 0x12) == 0:     # post-indexed
-            if emu._forrealz: emu.setRegister( self.base_reg, addr )
+            if (emu != None) and (emu._forrealz): emu.setRegister( self.base_reg, addr )
             return base
 
         return addr

--- a/envi/archs/arm/disasm.py
+++ b/envi/archs/arm/disasm.py
@@ -40,15 +40,6 @@ from envi.archs.arm.regs import *
 #   * Debug subsystem (coproc 14)
 #   * other 'default' coprocs we can handle and add value?
 
-#This holds the current running Arm instruction version and mask
-archVersion = 'ARMv7A'
-archVersionMask = ARCH_REVS['ARMv7A']
-
-def setArchVersion(key = 'ARMv7A'):
-    ''' set arch versions '''
-    archVersion = key
-    archVersionMask = ARCH_REVS[key]
-
 def chopmul(opcode):
     op1 = (opcode >> 20) & 0xff
     a = (opcode >> 16) & 0xf
@@ -2614,9 +2605,26 @@ ENDIAN_MSB = 1
 
 class ArmDisasm:
     fmt = None
+
+    #This holds the current running Arm instruction version and mask
+    _archVersion = 'ARMv7A'
+    _archVersionMask = ARCH_REVS['ARMv7A']
+
     def __init__(self, endian=ENDIAN_LSB):
         self.setEndian(endian)
         
+
+    def setArchVersion(key = 'ARMv7A'):
+    ''' set arch versions '''
+        archVersion = key
+        archVersionMask = ARCH_REVS[key]
+
+    def getArchMask()
+        return _archVersionMask
+
+    def getArchVersion()
+        return _archVersion
+    
     def setEndian(self, endian):
         self.fmt = ("<I", ">I")[endian]
 

--- a/envi/archs/arm/disasm.py
+++ b/envi/archs/arm/disasm.py
@@ -157,6 +157,25 @@ shifters = (
 dp_mnem = ("and","eor","sub","rsb","add","adc","sbc","rsc","tst","teq","cmp","cmn","orr","mov","bic","mvn",
         "adr")  # added
 
+#list of commands and versions supported:
+#putting full list here for now.
+#adc = v4, v5t, v6, v7
+#add = v4, v5t, v6, v7
+#adr = v4, v5t, v6, v7
+#and = v4, v5t, v6, v7
+#asr = v4, v5t, v6, v7
+#b = v4, v5t, v6, v7
+#bfc = v6t2, v7
+#bfi = v6t2, v7
+#bic = v4, v5t, v6, v7
+#bkpt = v5t, v6, v7
+#bl = v4, v5t, v6, v7
+#blx = v5t, v6, v7
+#bx = v4T, v5t, v6, v7
+#bxj = v5tej, v6, v7
+#cdp = v4, v5t, v6, v7
+#cdp2 = v5t, v6, v7
+
 # FIXME: THIS IS FUGLY but sadly it works
 dp_noRn = (13,15)
 dp_noRd = (8,9,10,11)
@@ -2697,7 +2716,7 @@ class ArmDisasm:
             raise envi.InvalidInstruction(mesg="No encoding found!",
                     bytez=bytez[offset:offset+4], va=va)
 
-        #print "ienc_parser index: %d" % enc
+        #print "ienc_parser index, routine: %d, %s" % (enc, ienc_parsers[enc])
         opcode, mnem, olist, flags = ienc_parsers[enc](opval, va+8)
         return opcode, mnem, olist, flags
 

--- a/envi/archs/arm/disasm.py
+++ b/envi/archs/arm/disasm.py
@@ -609,11 +609,16 @@ def p_mult(opval, va):
     opcode = (IENC_MULT << 16) + ocode
     return (opcode, mnem, olist, flags)
 
+#FIXME, ADR calculates at this point which I believe to be wrong
+#Will research when doing EMU portion.
 def p_dp_imm(opval, va):
     ocode,sflag,Rn,Rd = dpbase(opval)
     imm = opval & 0xff
-    rot = (opval >> 7) & 0x1f   # effectively, rot*2
-    
+    #FIXME: Original was (opval>> 7) & 0x1f which grabs top 5 bits
+    #supposed to be top 4 bits. Temp fix mask out wrong bit
+    #should be (opval >> 8) & 0xf
+    #need to find where rot / 2 and fix that.
+    rot = ((opval >> 7) & 0x1e)
     # hack to make add/sub against PC more readable (also legit for ADR instruction)
     if Rn == REG_PC and ocode in dp_ADR:    # we know PC
         if ocode == 2:  # and this is a subtraction

--- a/envi/archs/arm/disasm.py
+++ b/envi/archs/arm/disasm.py
@@ -2642,26 +2642,29 @@ ENDIAN_MSB = 1
 
 class ArmDisasm:
     fmt = None
-
     #This holds the current running Arm instruction version and mask
-    _archVersion = 'ARMv7A'
-    _archVersionMask = ARCH_REVS['ARMv7A']
+    _archVersionMask = 'ARMvA'
 
     def __init__(self, endian=ENDIAN_LSB):
+        self.setArchMask()
         self.setEndian(endian)
-        
 
-    def setArchVersion(key = 'ARMv7A'):
-        ''' set arch versions '''
-        archVersion = key
-        archVersionMask = ARCH_REVS[key]
+    def setArchMask(self, key = 'ARMv7R'):
+        ''' set arch version mask '''
+        if key in ARCH_REVS:
+            self._archVersionMask = ARCH_REVS[key]
+        elif key == 'thumb16':
+            self._archVersionMask = REV_THUMB16
+        elif key == 'thumb':
+            self._archVersionMask = REV_THUMB2
+        else:
+            #Not supported so no mask
+            #will include thumbee and any non supported arm versions.
+            self._archVersionMask = 0
 
-    def getArchMask():
-        return _archVersionMask
+    def getArchMask(self):
+        return self._archVersionMask
 
-    def getArchVersion():
-        return _archVersion
-    
     def setEndian(self, endian):
         self.fmt = ("<I", ">I")[endian]
 

--- a/envi/tests/test_arch_arm.py
+++ b/envi/tests/test_arch_arm.py
@@ -94,11 +94,8 @@ instrs = [
         (REV_ALL_ARM, '7745e3e0', 0x4560, 'rsc r4, r3, r7, ror r5', 0, ()),
         (REV_ALL_ARM, '7745f3e0', 0x4560, 'rscs r4, r3, r7, ror r5', 0, ()),
         (REV_ALL_ARM, '774513e1', 0x4560, 'tst r3, r7, ror r5', 0, ()),
-        #(REV_ALL_ARM, '774523e1', 0x4560, 'bkpt #0x3457', 0, ()), #Emu: Unsupported instruction
         (REV_ALL_ARM, '774533e1', 0x4560, 'teq r3, r7, ror r5', 0, ()),
-        #(REV_ALL_ARM, '774543e1', 0x4560, 'hvc #0x3457', 0, ()), # not implimented*
         (REV_ALL_ARM, '774553e1', 0x4560, 'cmp r3, r7, ror r5', 0, ()),
-        #(REV_ALL_ARM, '774563e1', 0x4560, 'smc #0x3457', 0, ()), # invalid - SB0 are not all 0
         (REV_ALL_ARM, '774573e1', 0x4560, 'cmn r3, r7, ror r5', 0, ()),
         (REV_ALL_ARM, '774583e1', 0x4560, 'orr r4, r3, r7, ror r5', 0, ()),
         (REV_ALL_ARM, '774593e1', 0x4560, 'orrs r4, r3, r7, ror r5', 0, ()),
@@ -124,13 +121,9 @@ instrs = [
         (REV_ALL_ARM, '8745d3e0', 0x4560, 'sbcs r4, r3, r7, lsl #11', 0, ()),
         (REV_ALL_ARM, '8745e3e0', 0x4560, 'rsc r4, r3, r7, lsl #11', 0, ()),
         (REV_ALL_ARM, '8745f3e0', 0x4560, 'rscs r4, r3, r7, lsl #11', 0, ()),
-        #(REV_ALL_ARM, '874503e1', 0x4560, 'smlabb r3, r7, r5, r4', 0, ()),  #TypeError: cannot concatenate 'str' and 'NoneType' objects
         (REV_ALL_ARM, '874513e1', 0x4560, 'tst r3, r7, lsl #11', 0, ()),
-        #(REV_ALL_ARM, '874523e1', 0x4560, 'smlawb r3, r7, r5, r4', 0, ()), #TypeError: cannot concatenate 'str' and 'NoneType' objects
         (REV_ALL_ARM, '874533e1', 0x4560, 'teq r3, r7, lsl #11', 0, ()),
-        #(REV_ALL_ARM, '874543e1', 0x4560, 'smlalbb r4, r3, r7, r5', 0, ()),  #UnboundLocalError: local variable 'Rn' referenced before assignment
         (REV_ALL_ARM, '874553e1', 0x4560, 'cmp r3, r7, lsl #11', 0, ()),
-        #(REV_ALL_ARM, '874563e1', 0x4560, 'smulbb r3, r7, r5', 0, ()), #Emu: Unsupported instruction
         (REV_ALL_ARM, '874573e1', 0x4560, 'cmn r3, r7, lsl #11', 0, ()),
         (REV_ALL_ARM, '874583e1', 0x4560, 'orr r4, r3, r7, lsl #11', 0, ()),
         (REV_ALL_ARM, '874593e1', 0x4560, 'orrs r4, r3, r7, lsl #11', 0, ()),
@@ -140,38 +133,12 @@ instrs = [
         (REV_ALL_ARM, '8745d3e1', 0x4560, 'bics r4, r3, r7, lsl #11', 0, ()),
         (REV_ALL_ARM, '8745e3e1', 0x4560, 'mvn r4, r7, lsl #11', 0, ()),
         (REV_ALL_ARM, '8745f3e1', 0x4560, 'mvns r4, r7, lsl #11', 0, ()),
-        #(REV_ALL_ARM, '974523e0', 0x4560, 'mla r3, r7, r5, r4', 0, ()), #Emu: Unsupported instruction
-        #(REV_ALL_ARM, '974533e0', 0x4560, 'mlas r3, r7, r5, r4', 0, ()), #Emu: Unsupported instruction
-        #(REV_ALL_ARM, '974543e0', 0x4560, 'umaal r4, r3, r7, r5', 0, ()), #Emu: Unsupported instruction
-        #(REV_ALL_ARM, '974553e0', 0x4560, 'umaals r4, r3, r7, r5', 0, ()), # not implimented - needs S flag support
-        (REV_ALL_ARM, '974563e0', 0x4560, 'mls r3, r7, r5, r4', 0, ()),  # not implimented
-        (REV_ALL_ARM, '974573e0', 0x4560, 'mlss r3, r7, r5, r4', 0, ()),   # not implimented
         (REV_ALL_ARM, '974583e0', 0x4560, 'umull r4, r3, r7, r5', 0, ()),
         (REV_ALL_ARM, '974593e0', 0x4560, 'umulls r4, r3, r7, r5', 0, ()),
         (REV_ALL_ARM, '9745a3e0', 0x4560, 'umlal r4, r3, r7, r5', 0, ()),
         (REV_ALL_ARM, '9745b3e0', 0x4560, 'umlals r4, r3, r7, r5', 0, ()),
         (REV_ALL_ARM, '9745c3e0', 0x4560, 'smull r4, r3, r7, r5', 0, ()),
         (REV_ALL_ARM, '9745d3e0', 0x4560, 'smulls r4, r3, r7, r5', 0, ()),
-        #(REV_ALL_ARM, '9745e3e0', 0x4560, 'smlal r4, r3, r7, r5', 0, ()), #Emu: Unsupported instruction
-        #(REV_ALL_ARM, '9745f3e0', 0x4560, 'smlals r4, r3, r7, r5', 0, ()), #Emu: Unsupported instruction
-        #next command IDA wrongly has as 'tst r3, r7, lsl r5'. Book shows this is the correct one minus the SBZ field is 0101; depreciated ARMv6
-        #(REV_ALL_ARM, '974503e1', 0x4560, 'swp r4, r7, [r3]', 0, ()), #Emu: Unsupported instruction
-        #(REV_ALL_ARM, '974513e1', 0x4560, 'tst r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
-        #(REV_ALL_ARM, '974523e1', 0x4560, 'teq r3, r7, lsl r5', 0, ()), # not valid - no sflag
-        #(REV_ALL_ARM, '974533e1', 0x4560, 'teq r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
-        #next command IDA wrongly has as 'cmp r3, r7, lsl r5'. Book shows this is the correct one minus the SBZ field is 0101; depreciated ARMv6
-        #(REV_ALL_ARM, '974543e1', 0x4560, 'swpb r4, r7, [r3]', 0, ()), #Emu: Unsupported instruction
-        #(REV_ALL_ARM, '974553e1', 0x4560, 'cmp r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
-        #(REV_ALL_ARM, '974563e1', 0x4560, 'cmn r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong - no Sflag
-        #(REV_ALL_ARM, '974573e1', 0x4560, 'cmn r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
-        #(REV_ALL_ARM, '974583e1', 0x4560, 'orr r4, r3, r7, lsl r5', 0, ()),  # not valid - bit 7 is wrong
-        #(REV_ALL_ARM, '974593e1', 0x4560, 'orrs r4, r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
-        #(REV_ALL_ARM, '9745a3e1', 0x4560, 'mov r4, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
-        #(REV_ALL_ARM, '9745b3e1', 0x4560, 'movs r4, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
-        #(REV_ALL_ARM, '9745c3e1', 0x4560, 'bic r4, r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
-        #(REV_ALL_ARM, '9745d3e1', 0x4560, 'bics r4, r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
-        #(REV_ALL_ARM, '9745e3e1', 0x4560, 'mvn r4, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
-        #(REV_ALL_ARM, '9745f3e1', 0x4560, 'mvns r4, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
         (REV_ALL_ARM, 'a74503e0', 0x4560, 'and r4, r3, r7, lsr #11', 0, ()),
         (REV_ALL_ARM, 'a74513e0', 0x4560, 'ands r4, r3, r7, lsr #11', 0, ()),
         (REV_ALL_ARM, 'a74523e0', 0x4560, 'eor r4, r3, r7, lsr #11', 0, ()),
@@ -188,13 +155,9 @@ instrs = [
         (REV_ALL_ARM, 'a745d3e0', 0x4560, 'sbcs r4, r3, r7, lsr #11', 0, ()),
         (REV_ALL_ARM, 'a745e3e0', 0x4560, 'rsc r4, r3, r7, lsr #11', 0, ()),
         (REV_ALL_ARM, 'a745f3e0', 0x4560, 'rscs r4, r3, r7, lsr #11', 0, ()),
-        #(REV_ALL_ARM, 'a74503e1', 0x4560, 'smlatb r3, r7, r5, r4', 0, ()), # not implimented
         (REV_ALL_ARM, 'a74513e1', 0x4560, 'tst r3, r7, lsr #11', 0, ()),
-        #(REV_ALL_ARM, 'a74523e1', 0x4560, 'smulwb r3, r7, r5', 0, ()), # not implimented
         (REV_ALL_ARM, 'a74533e1', 0x4560, 'teq r3, r7, lsr #11', 0, ()),
-        #(REV_ALL_ARM, 'a74543e1', 0x4560, 'smlaltb r4, r3, r7, r5', 0, ()), # not implimented
         (REV_ALL_ARM, 'a74553e1', 0x4560, 'cmp r3, r7, lsr #11', 0, ()),
-        #(REV_ALL_ARM, 'a74563e1', 0x4560, 'smultb r3, r7, r5', 0, ()), #Emu: Unsupported instruction
         (REV_ALL_ARM, 'a74573e1', 0x4560, 'cmn r3, r7, lsr #11', 0, ()),
         (REV_ALL_ARM, 'a74583e1', 0x4560, 'orr r4, r3, r7, lsr #11', 0, ()),
         (REV_ALL_ARM, 'a74593e1', 0x4560, 'orrs r4, r3, r7, lsr #11', 0, ()),
@@ -252,13 +215,9 @@ instrs = [
         (REV_ALL_ARM, 'c745d3e0', 0x4560, 'sbcs r4, r3, r7, asr #11', 0, ()),
         (REV_ALL_ARM, 'c745e3e0', 0x4560, 'rsc r4, r3, r7, asr #11', 0, ()),
         (REV_ALL_ARM, 'c745f3e0', 0x4560, 'rscs r4, r3, r7, asr #11', 0, ()),
-        #(REV_ALL_ARM, 'c74503e1', 0x4560, 'smlabt r3, r7, r5, r4', 0, ()), # not implimented
         (REV_ALL_ARM, 'c74513e1', 0x4560, 'tst r3, r7, asr #11', 0, ()),
-        #(REV_ALL_ARM, 'c74523e1', 0x4560, 'smlawt r3, r7, r5, r4', 0, ()), # not implimented
         (REV_ALL_ARM, 'c74533e1', 0x4560, 'teq r3, r7, asr #11', 0, ()),
-        #(REV_ALL_ARM, 'c74543e1', 0x4560, 'smlalbt r4, r3, r7, r5', 0, ()), # not implimented
         (REV_ALL_ARM, 'c74553e1', 0x4560, 'cmp r3, r7, asr #11', 0, ()),
-        #(REV_ALL_ARM, 'c74563e1', 0x4560, 'smulbt r3, r7, r5', 0, ()), #Emu: Unsupported instruction
         (REV_ALL_ARM, 'c74573e1', 0x4560, 'cmn r3, r7, asr #11', 0, ()),
         (REV_ALL_ARM, 'c74583e1', 0x4560, 'orr r4, r3, r7, asr #11', 0, ()),
         (REV_ALL_ARM, 'c74593e1', 0x4560, 'orrs r4, r3, r7, asr #11', 0, ()),
@@ -274,15 +233,12 @@ instrs = [
         (REV_ALL_ARM, 'd74533e0', 0x4560, 'ldrsbt r4, [r3], -r7 ', 0, ()),
         (REV_ALL_ARM, 'd74543e0', 0x4560, 'ldrd r4, [r3], #-0x57 ', 0, ()),
         (REV_ALL_ARM, 'd74553e0', 0x4560, 'ldrsb r4, [r3], #-0x57 ', 0, ()),
-        #(REV_ALL_ARM, 'd74563e0', 0x4560, 'ldrtd r4, [r3], #-0x57 ', 0, ()), # ldrd variant - unpredictable - not valid
         (REV_ALL_ARM, 'd74573e0', 0x4560, 'ldrsbt r4, [r3], #-0x57 ', 0, ()),
         (REV_ALL_ARM, 'd74583e0', 0x4560, 'ldrd r4, [r3], r7 ', 0, ()),
         (REV_ALL_ARM, 'd74593e0', 0x4560, 'ldrsb r4, [r3], r7 ', 0, ()),
-        #(REV_ALL_ARM, 'd745a3e0', 0x4560, 'ldrtd r4, [r3], r7 ', 0, ()), # ldrd variant - unpredictable - not valid
         (REV_ALL_ARM, 'd745b3e0', 0x4560, 'ldrsbt r4, [r3], r7 ', 0, ()),
         (REV_ALL_ARM, 'd745c3e0', 0x4560, 'ldrd r4, [r3], #0x57 ', 0, ()),
         (REV_ALL_ARM, 'd745d3e0', 0x4560, 'ldrsb r4, [r3], #0x57 ', 0, ()),
-        #(REV_ALL_ARM, 'd745e3e0', 0x4560, 'ldrtd r4, [r3], #0x57 ', 0, ()), # ldrd variant - unpredictable - not valid
         (REV_ALL_ARM, 'd745f3e0', 0x4560, 'ldrsbt r4, [r3], #0x57 ', 0, ()),
         (REV_ALL_ARM, 'd74503e1', 0x4560, 'ldrd r4, [r3, -r7] ', 0, ()),
         (REV_ALL_ARM, 'd74513e1', 0x4560, 'ldrsb r4, [r3, -r7] ', 0, ()),
@@ -316,13 +272,9 @@ instrs = [
         (REV_ALL_ARM, 'e745d3e0', 0x4560, 'sbcs r4, r3, r7, ror #11', 0, ()),
         (REV_ALL_ARM, 'e745e3e0', 0x4560, 'rsc r4, r3, r7, ror #11', 0, ()),
         (REV_ALL_ARM, 'e745f3e0', 0x4560, 'rscs r4, r3, r7, ror #11', 0, ()),
-        #(REV_ALL_ARM, 'e74503e1', 0x4560, 'smlatt r3, r7, r5, r4', 0, ()), # not implimented
         (REV_ALL_ARM, 'e74513e1', 0x4560, 'tst r3, r7, ror #11', 0, ()),
-        #(REV_ALL_ARM, 'e74523e1', 0x4560, 'smulwt r3, r7, r5', 0, ()), # not implimented
         (REV_ALL_ARM, 'e74533e1', 0x4560, 'teq r3, r7, ror #11', 0, ()),
-        #(REV_ALL_ARM, 'e74543e1', 0x4560, 'smlaltt r4, r3, r7, r5', 0, ()), # not implimented
         (REV_ALL_ARM, 'e74553e1', 0x4560, 'cmp r3, r7, ror #11', 0, ()),
-        #(REV_ALL_ARM, 'e74563e1', 0x4560, 'smultt r3, r7, r5', 0, ()), #Emu: Unsupported instruction
         (REV_ALL_ARM, 'e74573e1', 0x4560, 'cmn r3, r7, ror #11', 0, ()),
         (REV_ALL_ARM, 'e74583e1', 0x4560, 'orr r4, r3, r7, ror #11', 0, ()),
         (REV_ALL_ARM, 'e74593e1', 0x4560, 'orrs r4, r3, r7, ror #11', 0, ()),
@@ -334,19 +286,15 @@ instrs = [
         (REV_ALL_ARM, 'e745f3e1', 0x4560, 'mvns r4, r7, ror #11', 0, ()),
         (REV_ALL_ARM, 'f74503e0', 0x4560, 'strd r4, [r3], -r7 ', 0, ()),
         (REV_ALL_ARM, 'f74513e0', 0x4560, 'ldrsh r4, [r3], -r7 ', 0, ()),
-        #(REV_ALL_ARM, 'f74523e0', 0x4560, 'strtd r4, [r3], -r7 ', 0, ()),  # strd variant - unpredictable - not valid
         (REV_ALL_ARM, 'f74533e0', 0x4560, 'ldrsht r4, [r3], -r7 ', 0, ()),
         (REV_ALL_ARM, 'f74543e0', 0x4560, 'strd r4, [r3], #-0x57 ', 0, ()),
         (REV_ALL_ARM, 'f74553e0', 0x4560, 'ldrsh r4, [r3], #-0x57 ', 0, ()),
-        #(REV_ALL_ARM, 'f74563e0', 0x4560, 'strtd r4, [r3], #-0x57 ', 0, ()), # strd variant - unpredictable - not valid
         (REV_ALL_ARM, 'f74573e0', 0x4560, 'ldrsht r4, [r3], #-0x57 ', 0, ()),
         (REV_ALL_ARM, 'f74583e0', 0x4560, 'strd r4, [r3], r7 ', 0, ()),
         (REV_ALL_ARM, 'f74593e0', 0x4560, 'ldrsh r4, [r3], r7 ', 0, ()),
-        #(REV_ALL_ARM, 'f745a3e0', 0x4560, 'strtd r4, [r3], r7 ', 0, ()), # strd variant - unpredictable - not valid
         (REV_ALL_ARM, 'f745b3e0', 0x4560, 'ldrsht r4, [r3], r7 ', 0, ()),
         (REV_ALL_ARM, 'f745c3e0', 0x4560, 'strd r4, [r3], #0x57 ', 0, ()),
         (REV_ALL_ARM, 'f745d3e0', 0x4560, 'ldrsh r4, [r3], #0x57 ', 0, ()),
-        #(REV_ALL_ARM, 'f745e3e0', 0x4560, 'strtd r4, [r3], #0x57 ', 0, ()), # strd variant - unpredictable - not valid
         (REV_ALL_ARM, 'f745f3e0', 0x4560, 'ldrsht r4, [r3], #0x57 ', 0, ()),
         (REV_ALL_ARM, 'f74503e1', 0x4560, 'strd r4, [r3, -r7] ', 0, ()),
         (REV_ALL_ARM, 'f74513e1', 0x4560, 'ldrsh r4, [r3, -r7] ', 0, ()),
@@ -380,13 +328,9 @@ instrs = [
         (REV_ALL_ARM, '0746d3e0', 0x4560, 'sbcs r4, r3, r7, lsl #12', 0, ()),
         (REV_ALL_ARM, '0746e3e0', 0x4560, 'rsc r4, r3, r7, lsl #12', 0, ()),
         (REV_ALL_ARM, '0746f3e0', 0x4560, 'rscs r4, r3, r7, lsl #12', 0, ()),
-        #(REV_ALL_ARM, '074603e1', 0x4560, 'tst r3, r7, lsl #12', 0, ()), # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '074613e1', 0x4560, 'tst r3, r7, lsl #12', 0, ()),
-        #(REV_ALL_ARM, '074623e1', 0x4560, 'teq r3, r7, lsl #12', 0, ()), # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '074633e1', 0x4560, 'teq r3, r7, lsl #12', 0, ()),
-        #(REV_ALL_ARM, '074643e1', 0x4560, 'cmp r3, r7, lsl #12', 0, ()), # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '074653e1', 0x4560, 'cmp r3, r7, lsl #12', 0, ()),
-        #(REV_ALL_ARM, '074663e1', 0x4560, 'cmn r3, r7, lsl #12', 0, ()), # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '074673e1', 0x4560, 'cmn r3, r7, lsl #12', 0, ()),
         (REV_ALL_ARM, '074683e1', 0x4560, 'orr r4, r3, r7, lsl #12', 0, ()),
         (REV_ALL_ARM, '074693e1', 0x4560, 'orrs r4, r3, r7, lsl #12', 0, ()),
@@ -412,12 +356,9 @@ instrs = [
         (REV_ALL_ARM, '1746d3e0', 0x4560, 'sbcs r4, r3, r7, lsl r6', 0, ()),
         (REV_ALL_ARM, '1746e3e0', 0x4560, 'rsc r4, r3, r7, lsl r6', 0, ()),
         (REV_ALL_ARM, '1746f3e0', 0x4560, 'rscs r4, r3, r7, lsl r6', 0, ()),
-        #(REV_ALL_ARM, '174603e1', 0x4560, 'tst r3, r7, lsl r6', 0, ()),   # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '174613e1', 0x4560, 'tst r3, r7, lsl r6', 0, ()),
         (REV_ALL_ARM, '174623e1', 0x4560, 'bx r7', 0, ()),
-        #(REV_ALL_ARM, '174643e1', 0x4560, 'cmp r3, r7, lsl r6', 0, ()), # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '174653e1', 0x4560, 'cmp r3, r7, lsl r6', 0, ()),
-        #(REV_ALL_ARM, '174663e1', 0x4560, 'clz r4, r7', 0, ()), #Emu: Unsupported instruction
         (REV_ALL_ARM, '174673e1', 0x4560, 'cmn r3, r7, lsl r6', 0, ()),
         (REV_ALL_ARM, '174683e1', 0x4560, 'orr r4, r3, r7, lsl r6', 0, ()),
         (REV_ALL_ARM, '174693e1', 0x4560, 'orrs r4, r3, r7, lsl r6', 0, ()),
@@ -443,12 +384,8 @@ instrs = [
         (REV_ALL_ARM, '2746d3e0', 0x4560, 'sbcs r4, r3, r7, lsr #12', 0, ()),
         (REV_ALL_ARM, '2746e3e0', 0x4560, 'rsc r4, r3, r7, lsr #12', 0, ()),
         (REV_ALL_ARM, '2746f3e0', 0x4560, 'rscs r4, r3, r7, lsr #12', 0, ()),
-        #(REV_ALL_ARM, '274603e1', 0x4560, 'tst r3, r7, lsr #12', 0, ()),  # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '274613e1', 0x4560, 'tst r3, r7, lsr #12', 0, ()),
-        #(REV_ALL_ARM, '274623e1', 0x4560, 'bxj r7', 0, ()),  # not valid command - none of SBO fields are all 1's
-        #(REV_ALL_ARM, '274643e1', 0x4560, 'cmp r3, r7, lsr #12', 0, ()), # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '274653e1', 0x4560, 'cmp r3, r7, lsr #12', 0, ()),
-        #(REV_ALL_ARM, '274663e1', 0x4560, 'cmn r3, r7, lsr #12', 0, ()), # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '274673e1', 0x4560, 'cmn r3, r7, lsr #12', 0, ()),
         (REV_ALL_ARM, '274683e1', 0x4560, 'orr r4, r3, r7, lsr #12', 0, ()),
         (REV_ALL_ARM, '274693e1', 0x4560, 'orrs r4, r3, r7, lsr #12', 0, ()),
@@ -474,13 +411,10 @@ instrs = [
         (REV_ALL_ARM, '3746d3e0', 0x4560, 'sbcs r4, r3, r7, lsr r6', 0, ()),
         (REV_ALL_ARM, '3746e3e0', 0x4560, 'rsc r4, r3, r7, lsr r6', 0, ()),
         (REV_ALL_ARM, '3746f3e0', 0x4560, 'rscs r4, r3, r7, lsr r6', 0, ()),
-        #(REV_ALL_ARM, '374603e1', 0x4560, 'tst r3, r7, lsr r6', 0, ()),  # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '374613e1', 0x4560, 'tst r3, r7, lsr r6', 0, ()),
         (REV_ALL_ARM, '374623e1', 0x4560, 'blx r7', 0, ()),
         (REV_ALL_ARM, '374633e1', 0x4560, 'teq r3, r7, lsr r6', 0, ()),
-        #(REV_ALL_ARM, '374643e1', 0x4560, 'cmp r3, r7, lsr r6', 0, ()), # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '374653e1', 0x4560, 'cmp r3, r7, lsr r6', 0, ()),
-        #(REV_ALL_ARM, '374663e1', 0x4560, 'cmn r3, r7, lsr r6', 0, ()), # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '374673e1', 0x4560, 'cmn r3, r7, lsr r6', 0, ()),
         (REV_ALL_ARM, '374683e1', 0x4560, 'orr r4, r3, r7, lsr r6', 0, ()),
         (REV_ALL_ARM, '374693e1', 0x4560, 'orrs r4, r3, r7, lsr r6', 0, ()),
@@ -506,13 +440,9 @@ instrs = [
         (REV_ALL_ARM, '4746d3e0', 0x4560, 'sbcs r4, r3, r7, asr #12', 0, ()),
         (REV_ALL_ARM, '4746e3e0', 0x4560, 'rsc r4, r3, r7, asr #12', 0, ()),
         (REV_ALL_ARM, '4746f3e0', 0x4560, 'rscs r4, r3, r7, asr #12', 0, ()),
-        #(REV_ALL_ARM, '474603e1', 0x4560, 'tst r3, r7, asr #12', 0, ()),   # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '474613e1', 0x4560, 'tst r3, r7, asr #12', 0, ()),
-        #(REV_ALL_ARM, '474623e1', 0x4560, 'teq r3, r7, asr #12', 0, ()),    # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '474633e1', 0x4560, 'teq r3, r7, asr #12', 0, ()),
-        #(REV_ALL_ARM, '474643e1', 0x4560, 'cmp r3, r7, asr #12', 0, ()),   # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '474653e1', 0x4560, 'cmp r3, r7, asr #12', 0, ()),
-        #(REV_ALL_ARM, '474663e1', 0x4560, 'cmn r3, r7, asr #12', 0, ()),  # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '474673e1', 0x4560, 'cmn r3, r7, asr #12', 0, ()),
         (REV_ALL_ARM, '474683e1', 0x4560, 'orr r4, r3, r7, asr #12', 0, ()),
         (REV_ALL_ARM, '474693e1', 0x4560, 'orrs r4, r3, r7, asr #12', 0, ()),
@@ -538,13 +468,9 @@ instrs = [
         (REV_ALL_ARM, '5746d3e0', 0x4560, 'sbcs r4, r3, r7, asr r6', 0, ()),
         (REV_ALL_ARM, '5746e3e0', 0x4560, 'rsc r4, r3, r7, asr r6', 0, ()),
         (REV_ALL_ARM, '5746f3e0', 0x4560, 'rscs r4, r3, r7, asr r6', 0, ()),
-        #(REV_ALL_ARM, '574603e1', 0x4560, 'tst r3, r7, asr r6', 0, ()), # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '574613e1', 0x4560, 'tst r3, r7, asr r6', 0, ()),  
-        #(REV_ALL_ARM, '574623e1', 0x4560, 'teq r3, r7, asr r6', 0, ()),  # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '574633e1', 0x4560, 'teq r3, r7, asr r6', 0, ()),  
-        #(REV_ALL_ARM, '574643e1', 0x4560, 'cmp r3, r7, asr r6', 0, ()),  # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '574653e1', 0x4560, 'cmp r3, r7, asr r6', 0, ()),  
-        #(REV_ALL_ARM, '574663e1', 0x4560, 'cmn r3, r7, asr r6', 0, ()), # not valid command - same as next but no sflag which is required
         (REV_ALL_ARM, '574673e1', 0x4560, 'cmn r3, r7, asr r6', 0, ()),
         (REV_ALL_ARM, '574683e1', 0x4560, 'orr r4, r3, r7, asr r6', 0, ()),
         (REV_ALL_ARM, '574693e1', 0x4560, 'orrs r4, r3, r7, asr r6', 0, ()),
@@ -585,7 +511,94 @@ instrs = [
         (REV_ALL_ARM, '6745c3e0', 0x4560, 'sbc r4, r3, r7, ror #10', 0, ()),
         (REV_ALL_ARM, '6745d3e0', 0x4560, 'sbcs r4, r3, r7, ror #10', 0, ()),
         (REV_ALL_ARM, '6745e3e0', 0x4560, 'rsc r4, r3, r7, ror #10', 0, ()),
-        (REV_ALL_ARM, '6745f3e0', 0x4560, 'rscs r4, r3, r7, ror #10', 0, ())
+        (REV_ALL_ARM, '6745f3e0', 0x4560, 'rscs r4, r3, r7, ror #10', 0, ()),
+        #not implimented at all yet but should be valid
+        #(REV_ALL_ARM, '774543e1', 0x4560, 'hvc #0x3457', 0, ()), # not implimented - hypervisor
+        #(REV_ALL_ARM, '974563e0', 0x4560, 'mls r3, r7, r5, r4', 0, ()),  # not implimented
+        
+        #valid codes but not implimented in EMU yet. Put here so they will fail after other tests done
+        #doing this to check test coverage
+        #(REV_ALL_ARM, '174663e1', 0x4560, 'clz r4, r7', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, 'e74503e1', 0x4560, 'smlatt r3, r7, r5, r4', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, 'e74523e1', 0x4560, 'smulwt r3, r7, r5', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, 'e74543e1', 0x4560, 'smlaltt r4, r3, r7, r5', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, 'c74503e1', 0x4560, 'smlabt r3, r7, r5, r4', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, 'c74523e1', 0x4560, 'smlawt r3, r7, r5, r4', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, 'c74543e1', 0x4560, 'smlalbt r4, r3, r7, r5', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, 'c74503e1', 0x4560, 'smlabt r3, r7, r5, r4', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, 'c74523e1', 0x4560, 'smlawt r3, r7, r5, r4', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, 'c74543e1', 0x4560, 'smlalbt r4, r3, r7, r5', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, 'a74503e1', 0x4560, 'smlatb r3, r7, r5, r4', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, 'a74523e1', 0x4560, 'smulwb r3, r7, r5', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, 'a74543e1', 0x4560, 'smlaltb r4, r3, r7, r5', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, 'a74563e1', 0x4560, 'smultb r3, r7, r5', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, '774523e1', 0x4560, 'bkpt #0x3457', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, '9745e3e0', 0x4560, 'smlal r4, r3, r7, r5', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, '9745f3e0', 0x4560, 'smlals r4, r3, r7, r5', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, '974503e1', 0x4560, 'swp r4, r7, [r3]', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, '974543e1', 0x4560, 'swpb r4, r7, [r3]', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, '974523e0', 0x4560, 'mla r3, r7, r5, r4', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, '974533e0', 0x4560, 'mlas r3, r7, r5, r4', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, '974543e0', 0x4560, 'umaal r4, r3, r7, r5', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, '874503e1', 0x4560, 'smlabb r3, r7, r5, r4', 0, ()),  #Emu: Unsupported instruction
+        #(REV_ALL_ARM, '874523e1', 0x4560, 'smlawb r3, r7, r5, r4', 0, ()), #Emu: Unsupported instruction
+        #(REV_ALL_ARM, '874543e1', 0x4560, 'smlalbb r4, r3, r7, r5', 0, ()),  #Emu: Unsupported instruction
+        #(REV_ALL_ARM, '874563e1', 0x4560, 'smulbb r3, r7, r5', 0, ()), #Emu: Unsupported instruction
+
+        
+        #not valid codes - will save for now and retry when all commands have been added
+        #to see if they match up somewhere. Delete after v8 has been done
+        #(REV_ALL_ARM, '574663e1', 0x4560, 'cmn r3, r7, asr r6', 0, ()), # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '574643e1', 0x4560, 'cmp r3, r7, asr r6', 0, ()),  # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '574623e1', 0x4560, 'teq r3, r7, asr r6', 0, ()),  # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '574603e1', 0x4560, 'tst r3, r7, asr r6', 0, ()), # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '474603e1', 0x4560, 'tst r3, r7, asr #12', 0, ()),   # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '474623e1', 0x4560, 'teq r3, r7, asr #12', 0, ()),    # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '474643e1', 0x4560, 'cmp r3, r7, asr #12', 0, ()),   # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '474663e1', 0x4560, 'cmn r3, r7, asr #12', 0, ()),  # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '374603e1', 0x4560, 'tst r3, r7, lsr r6', 0, ()),  # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '374643e1', 0x4560, 'cmp r3, r7, lsr r6', 0, ()), # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '374663e1', 0x4560, 'cmn r3, r7, lsr r6', 0, ()), # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '274603e1', 0x4560, 'tst r3, r7, lsr #12', 0, ()),  # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '274623e1', 0x4560, 'bxj r7', 0, ()),  # not valid command - none of SBO fields are all 1's
+        #(REV_ALL_ARM, '274643e1', 0x4560, 'cmp r3, r7, lsr #12', 0, ()), # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '274663e1', 0x4560, 'cmn r3, r7, lsr #12', 0, ()), # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '174603e1', 0x4560, 'tst r3, r7, lsl r6', 0, ()),   # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '174643e1', 0x4560, 'cmp r3, r7, lsl r6', 0, ()), # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '074603e1', 0x4560, 'tst r3, r7, lsl #12', 0, ()), # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '074623e1', 0x4560, 'teq r3, r7, lsl #12', 0, ()), # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '074643e1', 0x4560, 'cmp r3, r7, lsl #12', 0, ()), # not valid command - no sflag which is required
+        #(REV_ALL_ARM, '074663e1', 0x4560, 'cmn r3, r7, lsl #12', 0, ()), # not valid command - no sflag which is required
+        #(REV_ALL_ARM, 'f745e3e0', 0x4560, 'strtd r4, [r3], #0x57 ', 0, ()), # strd variant - unpredictable - not valid
+        #(REV_ALL_ARM, 'f745a3e0', 0x4560, 'strtd r4, [r3], r7 ', 0, ()), # strd variant - unpredictable - not valid
+        #(REV_ALL_ARM, 'f74523e0', 0x4560, 'strtd r4, [r3], -r7 ', 0, ()),  # strd variant - unpredictable - not valid
+        #(REV_ALL_ARM, 'f74563e0', 0x4560, 'strtd r4, [r3], #-0x57 ', 0, ()), # strd variant - unpredictable - not valid
+        #(REV_ALL_ARM, 'e74563e1', 0x4560, 'smultt r3, r7, r5', 0, ()), # invalid command sbz had a 1 in it
+        #(REV_ALL_ARM, 'd74563e0', 0x4560, 'ldrtd r4, [r3], #-0x57 ', 0, ()), # ldrd variant - unpredictable - not valid
+        #(REV_ALL_ARM, 'd745a3e0', 0x4560, 'ldrtd r4, [r3], r7 ', 0, ()), # ldrd variant - unpredictable - not valid
+        #(REV_ALL_ARM, 'd745e3e0', 0x4560, 'ldrtd r4, [r3], #0x57 ', 0, ()), # ldrd variant - unpredictable - not valid
+        #(REV_ALL_ARM, 'c74563e1', 0x4560, 'smulbt r3, r7, r5', 0, ()), # invalid command sbz had a 1 in it
+        #(REV_ALL_ARM, 'c74563e1', 0x4560, 'smulbt r3, r7, r5', 0, ()), # invalid command sbz had a 1 in it
+        #(REV_ALL_ARM, '774563e1', 0x4560, 'smc #0x3457', 0, ()), # invalid - SB0 are not all 0
+        #next command IDA wrongly has as 'tst r3, r7, lsl r5'. Book shows this is the correct one minus the SBZ field is 0101; depreciated ARMv6
+        #(REV_ALL_ARM, '974513e1', 0x4560, 'tst r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
+        #(REV_ALL_ARM, '974523e1', 0x4560, 'teq r3, r7, lsl r5', 0, ()), # not valid - no sflag
+        #(REV_ALL_ARM, '974533e1', 0x4560, 'teq r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
+        #next command IDA wrongly has as 'cmp r3, r7, lsl r5'. Book shows this is the correct one minus the SBZ field is 0101; depreciated ARMv6
+        #(REV_ALL_ARM, '974553e1', 0x4560, 'cmp r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
+        #(REV_ALL_ARM, '974563e1', 0x4560, 'cmn r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong - no Sflag
+        #(REV_ALL_ARM, '974573e1', 0x4560, 'cmn r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
+        #(REV_ALL_ARM, '974583e1', 0x4560, 'orr r4, r3, r7, lsl r5', 0, ()),  # not valid - bit 7 is wrong
+        #(REV_ALL_ARM, '974593e1', 0x4560, 'orrs r4, r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
+        #(REV_ALL_ARM, '9745a3e1', 0x4560, 'mov r4, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
+        #(REV_ALL_ARM, '9745b3e1', 0x4560, 'movs r4, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
+        #(REV_ALL_ARM, '9745c3e1', 0x4560, 'bic r4, r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
+        #(REV_ALL_ARM, '9745d3e1', 0x4560, 'bics r4, r3, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
+        #(REV_ALL_ARM, '9745e3e1', 0x4560, 'mvn r4, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
+        #(REV_ALL_ARM, '9745f3e1', 0x4560, 'mvns r4, r7, lsl r5', 0, ()), # not valid - bit 7 is wrong
+        #(REV_ALL_ARM, '974553e0', 0x4560, 'umaals r4, r3, r7, r5', 0, ()), # invalid instruction
+        #(REV_ALL_ARM, '974573e0', 0x4560, 'mlss r3, r7, r5, r4', 0, ()),   # invalid instruction
+        
         ]
 
 
@@ -814,10 +827,10 @@ class ArmInstructionSet(unittest.TestCase):
                 test_arch = ARCH_REVS[key]
                 if ((not ranAlready) or (not self.armTestOnce)) and ((archz & test_arch & self.armTestVersion) != 0): 
                     ranAlready = True
-                    arm.ThumbModule.archVersion = arm.ArmModule.archVersion = key
-                    num, = struct.unpack("<I", bytez.decode('hex'))
-                    bs = bin(num)[2:].zfill(32)
-                    print bytez, bs
+                    arm.setArchVersion(key)
+                    #num, = struct.unpack("<I", bytez.decode('hex'))
+                    #bs = bin(num)[2:].zfill(32)
+                    #print bytez, bs
                     op = vw.arch.archParseOpcode(bytez.decode('hex'), 0, va)
                     redoprepr = repr(op).replace(' ','').lower()
                     redgoodop = reprOp.replace(' ','')

--- a/envi/tests/test_arch_arm.py
+++ b/envi/tests/test_arch_arm.py
@@ -543,30 +543,30 @@ instrs = [
         (REV_ALL_ARM, '073834ed', 0x4560, 'ldc p8, c3, [r4, #-0x1c]!', 0, ()),
         (REV_ALL_ARM, '0738b4ec', 0x4560, 'ldc p8, c3, [r4], #0x1c', 0, ()),
         (REV_ALL_ARM, '073834ec', 0x4560, 'ldc p8, c3, [r4], #-0x1c', 0, ()),
-        (REV_ALL_ARM, '073894ec', 0x4560, 'ldc p8, c3, [r4], #0x1c', 0, ()),  #option should not have # listed
+        (REV_ALL_ARM, '073894ec', 0x4560, 'ldc p8, c3, [r4], {7}', 0, ()),
         (REV_ALL_ARM, '0738d4ed', 0x4560, 'ldcl p8, c3, [r4, #0x1c]', 0, ()),
         (REV_ALL_ARM, '073854ed', 0x4560, 'ldcl p8, c3, [r4, #-0x1c]', 0, ()),
         (REV_ALL_ARM, '0738f4ed', 0x4560, 'ldcl p8, c3, [r4, #0x1c]!', 0, ()),
         (REV_ALL_ARM, '073874ed', 0x4560, 'ldcl p8, c3, [r4, #-0x1c]!', 0, ()),
         (REV_ALL_ARM, '0738f4ec', 0x4560, 'ldcl p8, c3, [r4], #0x1c', 0, ()),
         (REV_ALL_ARM, '073874ec', 0x4560, 'ldcl p8, c3, [r4], #-0x1c', 0, ()),
-        (REV_ALL_ARM, '0738d4ec', 0x4560, 'ldcl p8, c3, [r4], #0x1c', 0, ()),  #option should not have # listed
+        (REV_ALL_ARM, '0738d4ec', 0x4560, 'ldcl p8, c3, [r4], {7}', 0, ()),
+        #in progress testing and debugging
+        (REV_ALL_ARM, '07389fed', 0x4560, 'ldc p8, c3, [#0x4584]', 0, ()),
         (REV_ALL_ARM, '07381fed', 0x4560, 'ldc p8, c3, [#0x454c]', 0, ()),
-        (REV_ALL_ARM, '07383fed', 0x4560, 'ldc p8, c3, #0x4584', 0, ()), #broken
-        #(REV_ALL_ARM, '07389fec', 0x4560, 'ldc p8, c3, #0x1c', 0, ()), #broken
-        #(REV_ALL_ARM, '07385fed', 0x4560, 'ldcl p8, c3, [#0x454c]', 0, ()), #broken only returns 4c
-        #(REV_ALL_ARM, '07387fed', 0x4560, 'ldcl p8, c3, #0x4584', 0, ()), #broken
-        #(REV_ALL_ARM, '0738dfec', 0x4560, 'ldcl p8, c3, #0x1c', 0, ()), #broken
-        #Will fix issues then retest before moving following ones
-        #(REV_ALL_ARM, '07381ffd', 0x4560, 'ldc2 p8, c3, [#0x454c]', 0, ()),
-        #(REV_ALL_ARM, '07383ffd', 0x4560, 'ldc2 p8, c3, #0x4584', 0, ()), #broken
-        #(REV_ALL_ARM, '07389ffc', 0x4560, 'ldc2 p8, c3, #0x1c', 0, ()), #broken
-        #(REV_ALL_ARM, '07385ffd', 0x4560, 'ldc2l p8, c3, [#0x454c]', 0, ()),#broken only returns 4c
-        #(REV_ALL_ARM, '07387ffd', 0x4560, 'ldc2l p8, c3, #0x4584', 0, ()),
-        #(REV_ALL_ARM, '0738dffc', 0x4560, 'ldc2l p8, c3, #0x1c', 0, ()),
+        (REV_ALL_ARM, '0738bfed', 0x4560, 'ldc p8, c3, [#0x4584]', 0, ()),
+        (REV_ALL_ARM, '07383fed', 0x4560, 'ldc p8, c3, [#0x454c]', 0, ()),
+        (REV_ALL_ARM, '0738bfec', 0x4560, 'ldc p8, c3, [#0x4584]', 0, ()),
+        (REV_ALL_ARM, '07383fec', 0x4560, 'ldc p8, c3, [#0x454c]', 0, ()),
+        (REV_ALL_ARM, '07389fec', 0x4560, 'ldc p8, c3, [pc], {7}', 0, ()),
+        (REV_ALL_ARM, '0738dfed', 0x4560, 'ldcl p8, c3, [#0x4584]', 0, ()),
+        (REV_ALL_ARM, '07385fed', 0x4560, 'ldcl p8, c3, [#0x454c]', 0, ()),
+        (REV_ALL_ARM, '0738ffed', 0x4560, 'ldcl p8, c3, [#0x4584]', 0, ()),
+        (REV_ALL_ARM, '07387fed', 0x4560, 'ldcl p8, c3, [#0x454c]', 0, ()),
+        (REV_ALL_ARM, '0738ffec', 0x4560, 'ldcl p8, c3, [#0x4584]', 0, ()),
+        (REV_ALL_ARM, '07387fec', 0x4560, 'ldcl p8, c3, [#0x454c]', 0, ()),
+        (REV_ALL_ARM, '0738dfec', 0x4560, 'ldcl p8, c3, [pc], {7}', 0, ()),
         
-        #commands with issues
-
         #Not yet implimented
         #these next ones show up as mov r4, r3, asr #30
         #(REV_ALL_ARM, '434fa0e1', 0x4560, 'asr  r4, r3, #30', 0, ()),
@@ -920,10 +920,11 @@ class ArmInstructionSet(unittest.TestCase):
                 test_arch = ARCH_REVS[key]
                 if ((not ranAlready) or (not self.armTestOnce)) and ((archz & test_arch & self.armTestVersion) != 0): 
                     ranAlready = True
-                    #arm.setArchVersion(key)
+                    #print arm.ArmDisasm._archVersionMask
                     #num, = struct.unpack("<I", bytez.decode('hex'))
                     #bs = bin(num)[2:].zfill(32)
                     #print bytez, bs
+                    #in arm/init.py
                     op = vw.arch.archParseOpcode(bytez.decode('hex'), 0, va)
                     redoprepr = repr(op).replace(' ','').lower()
                     redgoodop = reprOp.replace(' ','')

--- a/envi/tests/test_arch_arm.py
+++ b/envi/tests/test_arch_arm.py
@@ -512,6 +512,51 @@ instrs = [
         (REV_ALL_ARM, '6745d3e0', 0x4560, 'sbcs r4, r3, r7, ror #10', 0, ()),
         (REV_ALL_ARM, '6745e3e0', 0x4560, 'rsc r4, r3, r7, ror #10', 0, ()),
         (REV_ALL_ARM, '6745f3e0', 0x4560, 'rscs r4, r3, r7, ror #10', 0, ()),
+        #ADDED TESTS
+        (REV_ALL_ARM, 'ff4ca3e2', 0x4560, 'adc  r4, r3, #0xff00', 0, ()),
+        (REV_ALL_ARM, 'ff4cb3e2', 0x4560, 'adcs  r4, r3, #0xff00', 0, ()),
+        (REV_ALL_ARM, 'ff4c83e2', 0x4560, 'add  r4, r3, #0xff00', 0, ()),
+        (REV_ALL_ARM, 'ff4c93e2', 0x4560, 'adds  r4, r3, #0xff00', 0, ()),
+        (REV_ALL_ARM, 'ff4c03e2', 0x4560, 'and  r4, r3, #0xff00', 0, ()),
+        (REV_ALL_ARM, 'ff4c13e2', 0x4560, 'ands  r4, r3, #0xff00', 0, ()),
+        (REV_ALL_ARM, '001000ea', 0x4560, 'b 0x00008568', 0, ()),
+        (REV_ALL_ARM, 'ff4cc3e3', 0x4560, 'bic  r4, r3, #0xff00', 0, ()),
+        (REV_ALL_ARM, '001000eb', 0x4560, 'bl  0x00008568', 0, ()),
+        (REV_ALL_ARM, '273764ee', 0x4560, 'cdp  p7, 6, c3, c4, c7, 1', 0, ()),
+        (REV_ALL_ARM, '473b34ee', 0x4560, 'cdp  p11, 3, c3, c4, c7, 2', 0, ()),
+
+        
+        #commands with issues
+
+        #ADR returns value calculated from PC. Not sure if this is correct.
+        #Believe for disassembly this should just show the number in the command.
+        #Will address later. Should be showing 0x1000 for the value on next two.
+        #Add to PC
+        (REV_ALL_ARM, '013a8fe2', 0x4560, 'adr  r3, 0x00005568', 0, ()),
+        # or sub r3, pc, #0x100 value before current instruction[pc]
+        (REV_ALL_ARM, '013a4fe2', 0x4560, 'adr  r3, 0x00003568', 0, ()),
+        #blx2? Should just be blx, just is 2nd variation.
+        #(REV_ALL_ARM, '001000fa', 0x4560, 'blx  0x00008568', 0, ()),
+        #shows up as cdp22
+        #(REV_ALL_ARM, '273764fe', 0x4560, 'cdp2  p7, 6, r3, r4, r7, 1', 0, ()),
+        #(REV_ALL_ARM, '473b34fe', 0x4560, 'cdp2  p11, 3, c3, c4, c7, 2', 0, ()),
+
+        
+        #Not yet implimented
+        #these next ones show up as mov r4, r3, asr #30
+        #(REV_ALL_ARM, '434fa0e1', 0x4560, 'asr  r4, r3, #30', 0, ()),
+        #(REV_ALL_ARM, '434fb0e1', 0x4560, 'asrs  r4, r3, #30', 0, ()),
+        #(REV_ALL_ARM, '5345a0e1', 0x4560, 'asr  r4, r3, r7', 0, ()),
+        #(REV_ALL_ARM, '5345b0e1', 0x4560, 'asrs  r4, r3, r7', 0, ()),
+        #(REV_ALL_ARM, '1f32cfe7', 0x4560, 'bfc r3, #16, #4', 0, ()),
+        #(REV_ALL_ARM, '1432cfe7', 0x4560, 'bfi r3, r4, #16, #4', 0, ()),
+
+        #implimented but not yet in emu
+        #(REV_ALL_ARM, '70f02fe1', 0x4560, 'bkpt  #0xff00', 0, ()),
+        #(REV_ALL_ARM, '24ff2fe1', 0x4560, 'bxj  r4', 0, ()), # note this switches to jazelle
+
+        #ORIGINAL TESTS
+        #start of commands with issues
         #not implimented at all yet but should be valid
         #(REV_ALL_ARM, '774543e1', 0x4560, 'hvc #0x3457', 0, ()), # not implimented - hypervisor
         #(REV_ALL_ARM, '974563e0', 0x4560, 'mls r3, r7, r5, r4', 0, ()),  # not implimented

--- a/envi/tests/test_arch_arm.py
+++ b/envi/tests/test_arch_arm.py
@@ -827,7 +827,7 @@ class ArmInstructionSet(unittest.TestCase):
                 test_arch = ARCH_REVS[key]
                 if ((not ranAlready) or (not self.armTestOnce)) and ((archz & test_arch & self.armTestVersion) != 0): 
                     ranAlready = True
-                    arm.setArchVersion(key)
+                    #arm.setArchVersion(key)
                     #num, = struct.unpack("<I", bytez.decode('hex'))
                     #bs = bin(num)[2:].zfill(32)
                     #print bytez, bs


### PR DESCRIPTION
Fix for literal lcdl normal form. Resolves issue of returning only 1 byte instead of 4 for the calculated address. OMJ! print was not removed at this time. 