### PR TITLE
Make ELF parser robust against imports defined at invalid addresses

### DIFF
--- a/vivisect/parsers/elf.py
+++ b/vivisect/parsers/elf.py
@@ -6,6 +6,7 @@ import collections
 import Elf
 import Elf.elf_lookup as elf_lookup
 
+import envi
 import envi.bits as e_bits
 import envi.const as e_const
 
@@ -744,36 +745,44 @@ def loadElfIntoWorkspace(vw, elf, filename=None, baseaddr=None):
             sva += baseoff
             if symname:
                 vw.makeName(sva, symname, filelocal=True, makeuniq=True)
-                valu = vw.readMemoryPtr(sva)
-                if not vw.isValidPointer(valu) and s.st_size == vw.psize:
-                    vw.makePointer(sva, follow=False)
-                else:
-                    '''
-                    Most of this is replicated in makePointer with follow=True. We specifically don't use that,
-                    since that kicks off a bunch of other analysis that isn't safe to run yet (it blows up in
-                    fun ways), but we still want these locations made first, so that other analysis modules know
-                    to not monkey with these and so I can set sizes and what not.
-                    And while ugly, this does cover a couple nice use cases like pointer tables/arrays of pointers being present.
-                    '''
-                    if not valu:
-                        # do a double check to make sure we can even make a pointer this large
-                        # because some relocations like __FRAME_END__ might end up short
-                        psize = vw.getPointerSize()
-                        byts = vw.readMemory(sva, psize)
-                        if len(byts) == psize:
-                            new_pointers.append((sva, valu, symname))
-                    elif vw.isProbablyUnicode(sva):
-                        vw.makeUnicode(sva, size=s.st_size)
-                    elif vw.isProbablyString(sva):
-                        vw.makeString(sva, size=s.st_size)
-                    elif s.st_size % vw.getPointerSize() == 0 and s.st_size >= vw.getPointerSize():
-                        # so it could be something silly like an array
-                        for addr in range(sva, sva+s.st_size, vw.psize):
-                            valu = vw.readMemoryPtr(addr)
-                            if vw.isValidPointer(valu):
-                                new_pointers.append((addr, valu, symname))
+
+                # Some ELF files define extra symbols that are not used by the 
+                # actual executable which can produce segment errors
+                try:
+                    valu = vw.readMemoryPtr(sva)
+                    if not vw.isValidPointer(valu) and s.st_size == vw.psize:
+                        vw.makePointer(sva, follow=False)
                     else:
-                        vw.makeNumber(sva, size=s.st_size)
+                        '''
+                        Most of this is replicated in makePointer with follow=True. We specifically don't use that,
+                        since that kicks off a bunch of other analysis that isn't safe to run yet (it blows up in
+                        fun ways), but we still want these locations made first, so that other analysis modules know
+                        to not monkey with these and so I can set sizes and what not.
+                        And while ugly, this does cover a couple nice use cases like pointer tables/arrays of pointers being present.
+                        '''
+                        if not valu:
+                            # do a double check to make sure we can even make a pointer this large
+                            # because some relocations like __FRAME_END__ might end up short
+                            psize = vw.getPointerSize()
+                            byts = vw.readMemory(sva, psize)
+                            if len(byts) == psize:
+                                new_pointers.append((sva, valu, symname))
+                        elif vw.isProbablyUnicode(sva):
+                            vw.makeUnicode(sva, size=s.st_size)
+                        elif vw.isProbablyString(sva):
+                            vw.makeString(sva, size=s.st_size)
+                        elif s.st_size % vw.getPointerSize() == 0 and s.st_size >= vw.getPointerSize():
+                            # so it could be something silly like an array
+                            for addr in range(sva, sva+s.st_size, vw.psize):
+                                valu = vw.readMemoryPtr(addr)
+                                if vw.isValidPointer(valu):
+                                    new_pointers.append((addr, valu, symname))
+                        else:
+                            vw.makeNumber(sva, size=s.st_size)
+
+                except envi.SegmentationViolation as e:
+                    logger.exception('Unable to add %s object from file %s', symname, fname)
+
 
         # if the symbol has a value of 0, it is likely a relocation point which gets updated
         sname = demangle(s.name)

--- a/vivisect/parsers/elf.py
+++ b/vivisect/parsers/elf.py
@@ -6,7 +6,6 @@ import collections
 import Elf
 import Elf.elf_lookup as elf_lookup
 
-import envi
 import envi.bits as e_bits
 import envi.const as e_const
 
@@ -82,6 +81,8 @@ def getMemoryMapInfo(elf, fname=None, baseaddr=None):
     '''
     memmaps = []
 
+    platform = elf.getPlatform()
+
     addbase, baseoff, baseaddr = getAddBaseAddr(elf, baseaddr)
 
     pgms = elf.getPheaders()
@@ -94,7 +95,14 @@ def getMemoryMapInfo(elf, fname=None, baseaddr=None):
             bytez += b'\x00' * (pgm.p_memsz - pgm.p_filesz)
             pva = pgm.p_vaddr
             pva += baseoff
-            memmaps.append((pva, pgm.p_flags & 0x7, fname, bytez, e_const.PAGE_SIZE))
+
+            # For posix-type platforms we should use the same page size that the 
+            # loader will use: 0x1000 (e_const.PAGE_SIZE). If the platform is 
+            # unknown use the alignmetn specified in the program header.
+            if platform == 'unknown':
+                memmaps.append((pva, pgm.p_flags & 0x7, fname, bytez, pgm.p_align))
+            else:
+                memmaps.append((pva, pgm.p_flags & 0x7, fname, bytez, e_const.PAGE_SIZE))
         else:
             logger.info('Skipping: %s', pgm)
 
@@ -361,9 +369,6 @@ def loadElfIntoWorkspace(vw, elf, filename=None, baseaddr=None):
     secs = elf.getSections()
 
     for mmapva, mmperms, mfname, mbytez, malign in getMemoryMapInfo(elf, fname, baseaddr):
-        if platform == 'unknown':
-            # unknown platforms 
-            malign = e_const.PAGE_SIZE
         logger.debug("vw.addMemoryMap(0x%x, 0x%x, %r, 0x%x, 0x%x)", mmapva, mmperms, mfname, len(mbytez), malign)
         vw.addMemoryMap(mmapva, mmperms, mfname, mbytez, malign)
 
@@ -745,44 +750,36 @@ def loadElfIntoWorkspace(vw, elf, filename=None, baseaddr=None):
             sva += baseoff
             if symname:
                 vw.makeName(sva, symname, filelocal=True, makeuniq=True)
-
-                # Some ELF files define extra symbols that are not used by the 
-                # actual executable which can produce segment errors
-                try:
-                    valu = vw.readMemoryPtr(sva)
-                    if not vw.isValidPointer(valu) and s.st_size == vw.psize:
-                        vw.makePointer(sva, follow=False)
+                valu = vw.readMemoryPtr(sva)
+                if not vw.isValidPointer(valu) and s.st_size == vw.psize:
+                    vw.makePointer(sva, follow=False)
+                else:
+                    '''
+                    Most of this is replicated in makePointer with follow=True. We specifically don't use that,
+                    since that kicks off a bunch of other analysis that isn't safe to run yet (it blows up in
+                    fun ways), but we still want these locations made first, so that other analysis modules know
+                    to not monkey with these and so I can set sizes and what not.
+                    And while ugly, this does cover a couple nice use cases like pointer tables/arrays of pointers being present.
+                    '''
+                    if not valu:
+                        # do a double check to make sure we can even make a pointer this large
+                        # because some relocations like __FRAME_END__ might end up short
+                        psize = vw.getPointerSize()
+                        byts = vw.readMemory(sva, psize)
+                        if len(byts) == psize:
+                            new_pointers.append((sva, valu, symname))
+                    elif vw.isProbablyUnicode(sva):
+                        vw.makeUnicode(sva, size=s.st_size)
+                    elif vw.isProbablyString(sva):
+                        vw.makeString(sva, size=s.st_size)
+                    elif s.st_size % vw.getPointerSize() == 0 and s.st_size >= vw.getPointerSize():
+                        # so it could be something silly like an array
+                        for addr in range(sva, sva+s.st_size, vw.psize):
+                            valu = vw.readMemoryPtr(addr)
+                            if vw.isValidPointer(valu):
+                                new_pointers.append((addr, valu, symname))
                     else:
-                        '''
-                        Most of this is replicated in makePointer with follow=True. We specifically don't use that,
-                        since that kicks off a bunch of other analysis that isn't safe to run yet (it blows up in
-                        fun ways), but we still want these locations made first, so that other analysis modules know
-                        to not monkey with these and so I can set sizes and what not.
-                        And while ugly, this does cover a couple nice use cases like pointer tables/arrays of pointers being present.
-                        '''
-                        if not valu:
-                            # do a double check to make sure we can even make a pointer this large
-                            # because some relocations like __FRAME_END__ might end up short
-                            psize = vw.getPointerSize()
-                            byts = vw.readMemory(sva, psize)
-                            if len(byts) == psize:
-                                new_pointers.append((sva, valu, symname))
-                        elif vw.isProbablyUnicode(sva):
-                            vw.makeUnicode(sva, size=s.st_size)
-                        elif vw.isProbablyString(sva):
-                            vw.makeString(sva, size=s.st_size)
-                        elif s.st_size % vw.getPointerSize() == 0 and s.st_size >= vw.getPointerSize():
-                            # so it could be something silly like an array
-                            for addr in range(sva, sva+s.st_size, vw.psize):
-                                valu = vw.readMemoryPtr(addr)
-                                if vw.isValidPointer(valu):
-                                    new_pointers.append((addr, valu, symname))
-                        else:
-                            vw.makeNumber(sva, size=s.st_size)
-
-                except envi.SegmentationViolation as e:
-                    logger.exception('Unable to add %s object from file %s', symname, fname)
-
+                        vw.makeNumber(sva, size=s.st_size)
 
         # if the symbol has a value of 0, it is likely a relocation point which gets updated
         sname = demangle(s.name)


### PR DESCRIPTION
Some PPC binaries that are meant to be loaded onto an external target have had objects like `_SDA_BASE_` set by the compiler but they are irrelevant for the final executable. So when the ELF is parsed if a symbol lies outside of the valid memory range it should just be ignored.

This can be reproduced with the following command:
```
$ vivbin -vvv -B ../vivtestfiles/raw/ppc/test_booke_vle.elf
```