### PR TITLE
Adding DBCR6 which was missing from the PPC SPR list

### DIFF
--- a/envi/archs/ppc/spr.py
+++ b/envi/archs/ppc/spr.py
@@ -199,6 +199,8 @@ sprs = {
     601: ("DVC1U", "Alias to high order 32 bits of DVC1 register. (alias", 32),
     602: ("DVC2U", "Alias to high order 32 bits of DVC2 register. (alias", 32),
 
+    603: ("DBCR6", " Debug control register 6 ", 32),
+
     # Hypervisor
     604: ("SPRG8", "SPRG8", 64),
     605: ("SPRG9", "SPRG9", 64),


### PR DESCRIPTION
Not a functional change, and the debug SPRs aren't used for anything, this is just to try and keep the list of PPC SPRs complete.