### PR TITLE
Fixing stepi/continue/break issues

### DIFF
--- a/vtrace/platforms/gdbstub.py
+++ b/vtrace/platforms/gdbstub.py
@@ -3378,6 +3378,9 @@ class GdbBaseEmuServer(GdbServerStub):
         if reggrps is None:
             reggrps = [('general', 'org.gnu.gdb.i386.core')]
 
+        if haltregs is None:
+            haltregs = []
+
         # TODO: Support custom register index numbers?
         # TODO: handle custom types such as those used by vector registers
 

--- a/vtrace/tests/tests_gdbstub.py
+++ b/vtrace/tests/tests_gdbstub.py
@@ -596,8 +596,7 @@ class TestGdbClientStub(unittest.TestCase):
             #
             # (this can change slightly depending on the amount of memory 
             # consumed by the GDB stub class)
-            self.assertIn(registers['rsp'],
-                          (0x40007ffa50, 0x40007ffa60, 0x40007ffaa0))
+            self.assertIn(registers['rsp'], range(0x40007ff930, 0x40007ffab0, 0x10))
 
             # CR0 registers only available over QEMU
             self.assertEqual(registers['cr0'], 0x80010001)


### PR DESCRIPTION
With the PPC e200 emulator there were inconsistencies about how stop/halt information was being sent to the GDB client that caused issues with how some of the gdb commands were handled. this PR addresses those issues.