### PR TITLE
Fix PE section-header offset when NumberOfRvaAndSizes is short

### DIFF
--- a/PE/__init__.py
+++ b/PE/__init__.py
@@ -745,9 +745,9 @@ class PE(object):
     def parseSections(self):
 
         self.sections = []
-        off = self.IMAGE_DOS_HEADER.e_lfanew + len(self.IMAGE_NT_HEADERS)
-        off -= len(self.IMAGE_NT_HEADERS.OptionalHeader.DataDirectory)
-        off += self.IMAGE_NT_HEADERS.OptionalHeader.NumberOfRvaAndSizes * len(vstruct.getStructure("pe.IMAGE_DATA_DIRECTORY"))
+        off = self.IMAGE_DOS_HEADER.e_lfanew + 4
+        off += len(self.IMAGE_NT_HEADERS.FileHeader)
+        off += self.IMAGE_NT_HEADERS.FileHeader.SizeOfOptionalHeader
 
         secsize = len(vstruct.getStructure("pe.IMAGE_SECTION_HEADER"))
         hdrsize = secsize * self.IMAGE_NT_HEADERS.FileHeader.NumberOfSections

--- a/vivisect/tests/testpe.py
+++ b/vivisect/tests/testpe.py
@@ -1,8 +1,10 @@
 import logging
+import struct
 import unittest
 
 import PE
 import envi.const as e_const
+import vstruct.defs.pe as vs_pe
 
 import vivisect
 import vivisect.const as viv_con
@@ -12,6 +14,63 @@ import vivisect.tests.helpers as helpers
 import vivisect.tests.utils as v_t_utils
 
 logger = logging.getLogger(__name__)
+
+
+def _build_minimal_pe_with_num_rva_and_sizes(num_rva_and_sizes=16):
+    dos = vs_pe.IMAGE_DOS_HEADER()
+    dos.e_magic = 0x5A4D
+    dos.e_lfanew = 0x80
+
+    nt = vs_pe.IMAGE_NT_HEADERS()
+    nt.Signature = b'PE\x00\x00'
+    nt.FileHeader.Machine = PE.IMAGE_FILE_MACHINE_I386
+    nt.FileHeader.NumberOfSections = 1
+    nt.FileHeader.SizeOfOptionalHeader = len(nt.OptionalHeader)
+    nt.FileHeader.Characteristics = PE.IMAGE_FILE_EXECUTABLE_IMAGE | PE.IMAGE_FILE_32BIT_MACHINE
+
+    nt.OptionalHeader.Magic = struct.pack('<H', PE.PE32_MAGIC)
+    nt.OptionalHeader.AddressOfEntryPoint = 0x1000
+    nt.OptionalHeader.BaseOfCode = 0x1000
+    nt.OptionalHeader.BaseOfData = 0x2000
+    nt.OptionalHeader.ImageBase = 0x400000
+    nt.OptionalHeader.SectionAlignment = 0x1000
+    nt.OptionalHeader.FileAlignment = 0x200
+    nt.OptionalHeader.SizeOfImage = 0x2000
+    nt.OptionalHeader.SizeOfHeaders = 0x200
+    nt.OptionalHeader.Subsystem = PE.IMAGE_SUBSYSTEM_WINDOWS_CUI
+    nt.OptionalHeader.SizeOfStackReserve = 0x100000
+    nt.OptionalHeader.SizeOfStackCommit = 0x1000
+    nt.OptionalHeader.SizeOfHeapReserve = 0x100000
+    nt.OptionalHeader.SizeOfHeapCommit = 0x1000
+    nt.OptionalHeader.NumberOfRvaAndSizes = num_rva_and_sizes
+
+    sec = vs_pe.IMAGE_SECTION_HEADER()
+    sec.Name = b'.text\x00\x00\x00'
+    sec.VirtualSize = 0x1234
+    sec.VirtualAddress = 0x1000
+    sec.SizeOfRawData = 0x200
+    sec.PointerToRawData = 0x200
+    sec.Characteristics = 0x60000020
+
+    raw = bytearray(0x400)
+    raw[:len(dos)] = dos.vsEmit()
+    raw[dos.e_lfanew:dos.e_lfanew + len(nt)] = nt.vsEmit()
+    sec_off = dos.e_lfanew + 4 + len(nt.FileHeader) + nt.FileHeader.SizeOfOptionalHeader
+    raw[sec_off:sec_off + len(sec)] = sec.vsEmit()
+    return bytes(raw), sec_off
+
+
+class PEBugRegressionTests(unittest.TestCase):
+
+    def test_parse_sections_uses_size_of_optional_header_for_offset(self):
+        raw, expected_sec_off = _build_minimal_pe_with_num_rva_and_sizes(15)
+
+        pe = PE.peFromBytes(raw)
+
+        self.assertEqual(pe.sections[0].vsGetMeta('Offset'), expected_sec_off)
+        self.assertEqual(pe.sections[0].Name, '.text\x00\x00\x00')
+        self.assertEqual(pe.sections[0].VirtualSize, 0x1234)
+        self.assertEqual(pe.sections[0].VirtualAddress, 0x1000)
 
 
 class PETests(v_t_utils.VivTest):


### PR DESCRIPTION
Summary:
- compute the section-table offset from e_lfanew + IMAGE_FILE_HEADER + SizeOfOptionalHeader
- stop deriving the section-table offset from NumberOfRvaAndSizes
- add a regression test for malformed PE32 files with a short NumberOfRvaAndSizes value

Why:
Issue #635 reports memory exhaustion caused by incorrect section parsing. The old code could walk backward into the optional header when NumberOfRvaAndSizes was smaller than the serialized DataDirectory length, which corrupted section metadata and could cascade into absurd memory map sizes.

Testing:
- ./.venv/bin/python -m pytest vivisect/tests/testpe.py -k parse_sections_uses_size_of_optional_header_for_offset -q
- ./.venv/bin/python -m py_compile PE/__init__.py vivisect/tests/testpe.py

Notes:
- regression test uses a synthetic PE32 image so it does not depend on external VIVTESTFILES fixtures
