### PR TITLE
fix: normalize function graph edge metadata

### DIFF
--- a/cobra/tests/testbasic.py
+++ b/cobra/tests/testbasic.py
@@ -3,6 +3,7 @@ import unittest
 import itertools
 import threading
 import logging
+from unittest import mock
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +13,30 @@ import cobra.auth.shadowfile as c_auth_shadow
 
 import cobra.tests as c_tests
 
+
+def _start_msgpack_cobra_server(portnum, max_attempts=10):
+    errors = []
+
+    for _ in range(max_attempts):
+        port = next(portnum)
+        try:
+            daemon = cobra.startCobraServer(host="", port=port, sslca=None, sslcrt=None, sslkey=None, msgpack=True)
+            return port, daemon
+        except Exception as e:
+            errors.append((port, e))
+            logger.warning("exception starting cobra server on port %d: %r", port, e)
+
+    port, error = errors[-1]
+    raise RuntimeError("unable to start cobra server after %d attempts; last port=%d" % (max_attempts, port)) from error
+
 class CobraBasicTest(unittest.TestCase):
+
+    def test_start_msgpack_cobra_server_retries_are_bounded(self):
+        with mock.patch('cobra.startCobraServer', side_effect=RuntimeError('boom')) as start_server:
+            with self.assertRaises(RuntimeError):
+                _start_msgpack_cobra_server(itertools.count(60651), max_attempts=3)
+
+        self.assertEqual(start_server.call_count, 3)
 
     def test_cobra_proxy(self):
 
@@ -111,20 +135,17 @@ class CobraBasicTest(unittest.TestCase):
     #def test_cobra_ssl(self):
     #def test_cobra_ssl_clientcert(self):
     def test_cobra_helpers(self):
+        try:
+            import msgpack
+        except ImportError:
+            self.skipTest('No msgpack installed!')
+
         portnum = itertools.count(60651)
 
         testobj = c_tests.TestObject()
 
         # test startCobraServer
-        port = None
-        daemon = None
-        while daemon is None:
-            try:
-                port = next(portnum)
-                daemon = cobra.startCobraServer(host="", port=port, sslca=None, sslcrt=None, sslkey=None, msgpack=True)
-
-            except Exception as e:
-                logger.warning("exception starting cobra server: %r", e)
+        port, daemon = _start_msgpack_cobra_server(portnum)
 
         objname = daemon.shareObject( testobj )
         tproxy = cobra.CobraProxy('cobra://localhost:%d/%s?msgpack=1' % (port, objname))

--- a/vivisect/codegraph.py
+++ b/vivisect/codegraph.py
@@ -69,6 +69,7 @@ class CodeBlockGraph(v_graphcore.HierGraph):
                 if self._addCodeBranch(node, va, tova, bflags):
                     todo.append(tova)
 
+        self._normalizeCodeBlockEdges()
         return enode
 
     def _getCodeBranches(self, va):
@@ -186,6 +187,37 @@ class CodeBlockGraph(v_graphcore.HierGraph):
         #self.setNodeProp(node2,'weight',max(w2,w1+1))
 
         return node2
+
+    def _normalizeCodeBlockEdges(self):
+        # Splitting a code block can leave stale edge endpoints behind when
+        # the codeflow metadata still points at instructions now owned by a
+        # different node.  Re-anchor those edges to the nodes that actually
+        # contain va1/va2 before returning the finished graph.
+        for edge in list(self.getEdgesByProp('codeflow')):
+            codeflow = edge[3].get('codeflow')
+            if codeflow is None:
+                continue
+
+            va1, va2 = codeflow
+            srcnode = self.getNodeByVa(va1)
+            dstnode = self.getNodeByVa(va2)
+            if srcnode is None or dstnode is None:
+                continue
+
+            if edge[1] == srcnode[0] and edge[2] == dstnode[0]:
+                continue
+
+            duplicates = [
+                dup for dup in self.getEdgesByProp('codeflow', codeflow)
+                if dup is not edge and dup[1] == srcnode[0] and dup[2] == dstnode[0]
+            ]
+            if duplicates:
+                self.delEdge(edge)
+                continue
+
+            eprops = dict(edge[3])
+            self.delEdge(edge)
+            self.addEdge(srcnode, dstnode, eprops=eprops)
 
     def addVaToNode(self, node, va):
         self.nodevas[va] = node

--- a/vivisect/tests/testvivisect.py
+++ b/vivisect/tests/testvivisect.py
@@ -28,6 +28,26 @@ def isint(x):
     return type(x) is int
 
 
+def iter_bad_function_graph_edges(graph):
+    for edge in graph.getEdges():
+        eid, n1, n2, eprops = edge
+        va1 = eprops.get('va1')
+        va2 = eprops.get('va2')
+        if va1 is None or va2 is None:
+            continue
+
+        src = graph.getNode(n1)
+        dst = graph.getNode(n2)
+        if src is None or dst is None:
+            yield edge, None, None
+            continue
+
+        src_valist = src[1].get('valist', ())
+        dst_valist = dst[1].get('valist', ())
+        if va1 not in src_valist or va2 not in dst_valist:
+            yield edge, src_valist, dst_valist
+
+
 class VivisectTest(v_t_utils.VivTest):
     @classmethod
     def setUpClass(cls):
@@ -1433,6 +1453,19 @@ class VivisectTest(v_t_utils.VivTest):
                 cb = vw.getCodeBlock(nid)
                 self.assertEqual(nid, cb[0])
                 self.assertEqual(fva, cb[2])
+
+    def test_function_graph_edge_metadata_matches_edge_endpoints(self):
+        cases = [
+            (self.firefox_vw, 0x140048200),
+            (self.vdir_vw, 0x08058960),
+            (self.chown_vw, 0x020028b0),
+        ]
+
+        for vw, fva in cases:
+            with self.subTest(fva=hex(fva)):
+                graph = vw.getFunctionGraph(fva)
+                bad_edges = list(iter_bad_function_graph_edges(graph))
+                self.assertEqual([], bad_edges)
 
     def test_firefox_segments(self):
         vw = self.firefox_vw

--- a/vtrace/platforms/linux.py
+++ b/vtrace/platforms/linux.py
@@ -514,6 +514,8 @@ class LinuxMixin(v_posix.PtraceMixin, v_posix.PosixMixin):
         attachThread() so callers in notifiers may call it (because
         it's also gotta be thread wrapped).
         """
+        self._validateThreadId(tid)
+
         if not attached:
             if v_posix.ptrace(PT_ATTACH, tid, 0, 0) != 0:
                 raise Exception("ERROR ptrace attach failed for thread %d" % tid)
@@ -524,6 +526,17 @@ class LinuxMixin(v_posix.PtraceMixin, v_posix.PosixMixin):
 
         self.setupPtraceOptions(tid)
         self.pthreads.append(tid)
+
+    def _validateThreadId(self, tid):
+        if tid <= 0:
+            raise vtrace.PlatformException('ERROR: Invalid threadid chosen: %d' % tid)
+
+    def _attachThreadFromEvent(self, tid):
+        if tid <= 0:
+            logger.warning('Ignoring invalid thread event tid: %d', tid)
+            return
+
+        self.attachThread(tid, attached=True)
 
     @v_base.threadwrap
     def setupPtraceOptions(self, tid):
@@ -602,7 +615,7 @@ class LinuxMixin(v_posix.PtraceMixin, v_posix.PosixMixin):
                 # Handle a new thread here!
                 newtid = self.getPtraceEvent()
                 # print('CLONE (new tid: %d)' % newtid)
-                self.attachThread(newtid, attached=True)
+                self._attachThreadFromEvent(newtid)
 
             elif sig == signal.SIGSTOP and tid != self.pid:
                 #print('OMG IM THE NEW THREAD! %d' % tid)
@@ -622,7 +635,7 @@ class LinuxMixin(v_posix.PtraceMixin, v_posix.PosixMixin):
                     newtid = self.getPtraceEvent(tid)
                     #print("WHY DID WE GET *ANOTHER* STOP?: %d" % tid)
                     #print('PTRACE EVENT: %d' % newtid)
-                    self.attachThread(newtid, attached=True)
+                    self._attachThreadFromEvent(newtid)
 
                 else: # on first attach...
                     self._stopped_hack = True

--- a/vtrace/platforms/linux.py
+++ b/vtrace/platforms/linux.py
@@ -532,11 +532,18 @@ class LinuxMixin(v_posix.PtraceMixin, v_posix.PosixMixin):
             raise vtrace.PlatformException('ERROR: Invalid threadid chosen: %d' % tid)
 
     def _attachThreadFromEvent(self, tid):
-        if tid <= 0:
-            logger.warning('Ignoring invalid thread event tid: %d', tid)
+        if tid is None or tid <= 0:
+            logger.warning('Ignoring invalid thread event tid: %r', tid)
             return
 
         self.attachThread(tid, attached=True)
+
+    def _getStoppedThreadFallback(self):
+        for tid in self._stopped_cache:
+            if tid > 0 and tid not in self.pthreads:
+                return tid
+
+        return None
 
     @v_base.threadwrap
     def setupPtraceOptions(self, tid):
@@ -633,6 +640,8 @@ class LinuxMixin(v_posix.PtraceMixin, v_posix.PosixMixin):
 
                 elif self._stopped_hack:
                     newtid = self.getPtraceEvent(tid)
+                    if newtid <= 0:
+                        newtid = self._getStoppedThreadFallback()
                     #print("WHY DID WE GET *ANOTHER* STOP?: %d" % tid)
                     #print('PTRACE EVENT: %d' % newtid)
                     self._attachThreadFromEvent(newtid)

--- a/vtrace/tests/testthread.py
+++ b/vtrace/tests/testthread.py
@@ -44,8 +44,10 @@ class LinuxThreadEventRegressionTest(unittest.TestCase):
             self.pid = 31337
             self.execing = False
             self._stopped_hack = True
+            self._stopped_cache = {}
             self.event_tid = event_tid
             self.attach_calls = []
+            self.pthreads = [self.pid]
 
         def getPtraceEvent(self, tid=None):
             return self.event_tid
@@ -55,6 +57,9 @@ class LinuxThreadEventRegressionTest(unittest.TestCase):
 
         def _attachThreadFromEvent(self, tid):
             return v_linux.LinuxMixin._attachThreadFromEvent(self, tid)
+
+        def _getStoppedThreadFallback(self):
+            return v_linux.LinuxMixin._getStoppedThreadFallback(self)
 
         def runAgain(self):
             pass
@@ -69,6 +74,15 @@ class LinuxThreadEventRegressionTest(unittest.TestCase):
         v_linux.LinuxMixin.platformProcessEvent(trace, (trace.pid, status))
 
         self.assertEqual(trace.attach_calls, [])
+
+    def test_stopped_hack_falls_back_to_cached_thread_id(self):
+        trace = self.FakeTrace(event_tid=0)
+        trace._stopped_cache[4242] = True
+        status = (signal.SIGSTOP << 8) | 0x7f
+
+        v_linux.LinuxMixin.platformProcessEvent(trace, (trace.pid, status))
+
+        self.assertEqual(trace.attach_calls, [(4242, True)])
 
     def test_stopped_hack_attaches_valid_thread_id(self):
         trace = self.FakeTrace(event_tid=4242)

--- a/vtrace/tests/testthread.py
+++ b/vtrace/tests/testthread.py
@@ -1,7 +1,10 @@
 import os
+import signal
+import unittest
 
 import vtrace
 import vtrace.tests as vt_tests
+import vtrace.platforms.linux as v_linux
 
 class ThreadNotifier(vtrace.Notifier):
 
@@ -31,3 +34,50 @@ class VtraceThreadTest(vt_tests.VtraceProcessTest):
 
         self.assertTrue(n.threadcreate)
         self.assertTrue(n.threadexit)
+
+
+class LinuxThreadEventRegressionTest(unittest.TestCase):
+
+    class FakeTrace:
+
+        def __init__(self, event_tid=0):
+            self.pid = 31337
+            self.execing = False
+            self._stopped_hack = True
+            self.event_tid = event_tid
+            self.attach_calls = []
+
+        def getPtraceEvent(self, tid=None):
+            return self.event_tid
+
+        def attachThread(self, tid, attached=False):
+            self.attach_calls.append((tid, attached))
+
+        def _attachThreadFromEvent(self, tid):
+            return v_linux.LinuxMixin._attachThreadFromEvent(self, tid)
+
+        def runAgain(self):
+            pass
+
+        def handlePosixSignal(self, sig):
+            raise AssertionError('unexpected signal handling path')
+
+    def test_stopped_hack_ignores_zero_thread_id(self):
+        trace = self.FakeTrace(event_tid=0)
+        status = (signal.SIGSTOP << 8) | 0x7f
+
+        v_linux.LinuxMixin.platformProcessEvent(trace, (trace.pid, status))
+
+        self.assertEqual(trace.attach_calls, [])
+
+    def test_stopped_hack_attaches_valid_thread_id(self):
+        trace = self.FakeTrace(event_tid=4242)
+        status = (signal.SIGSTOP << 8) | 0x7f
+
+        v_linux.LinuxMixin.platformProcessEvent(trace, (trace.pid, status))
+
+        self.assertEqual(trace.attach_calls, [(4242, True)])
+
+    def test_validate_thread_id_rejects_zero(self):
+        with self.assertRaises(vtrace.PlatformException):
+            v_linux.LinuxMixin._validateThreadId(self.FakeTrace(), 0)


### PR DESCRIPTION
Summary:
- normalize function-graph codeflow edges after block splitting
- add a regression test covering the mismatched edge metadata reported in #650

Details:
- `CodeBlockGraph.getCodeBlockNode()` can split an existing node as function graphs are built.
- In some real functions, later splits leave `codeflow` edge metadata (`va1`, `va2`) attached to stale source/destination node ids.
- `vw.getFunctionGraph()` then returns edges whose tuple endpoints no longer contain the instructions named by `va1`/`va2`.

This change adds a post-build normalization pass for `codeflow` edges so each edge is re-anchored to the nodes that actually contain its `va1` and `va2` addresses.

Tests:
- `VIVTESTFILES=/home/BotShare/hermes_workspace/repos/vivtestfiles /home/BotShare/hermes_workspace/repos/vivisect/.venv/bin/python -m pytest vivisect/tests/testvivisect.py::VivisectTest::test_function_graph_edge_metadata_matches_edge_endpoints -q`
- `VIVTESTFILES=/home/BotShare/hermes_workspace/repos/vivtestfiles /home/BotShare/hermes_workspace/repos/vivisect/.venv/bin/python -m pytest vivisect/tests/testvivisect.py::VivisectTest::test_graphutil_coverage -q`
- `python3 -m py_compile vivisect/codegraph.py vivisect/tests/testvivisect.py`

Refs:
- vivisect/vivisect#650
