### PR TITLE
Fix intermittent Linux vtrace thread hangs and bound Cobra retry loop

### DIFF
--- a/cobra/tests/testbasic.py
+++ b/cobra/tests/testbasic.py
@@ -3,6 +3,7 @@ import unittest
 import itertools
 import threading
 import logging
+from unittest import mock
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +13,30 @@ import cobra.auth.shadowfile as c_auth_shadow
 
 import cobra.tests as c_tests
 
+
+def _start_msgpack_cobra_server(portnum, max_attempts=10):
+    errors = []
+
+    for _ in range(max_attempts):
+        port = next(portnum)
+        try:
+            daemon = cobra.startCobraServer(host="", port=port, sslca=None, sslcrt=None, sslkey=None, msgpack=True)
+            return port, daemon
+        except Exception as e:
+            errors.append((port, e))
+            logger.warning("exception starting cobra server on port %d: %r", port, e)
+
+    port, error = errors[-1]
+    raise RuntimeError("unable to start cobra server after %d attempts; last port=%d" % (max_attempts, port)) from error
+
 class CobraBasicTest(unittest.TestCase):
+
+    def test_start_msgpack_cobra_server_retries_are_bounded(self):
+        with mock.patch('cobra.startCobraServer', side_effect=RuntimeError('boom')) as start_server:
+            with self.assertRaises(RuntimeError):
+                _start_msgpack_cobra_server(itertools.count(60651), max_attempts=3)
+
+        self.assertEqual(start_server.call_count, 3)
 
     def test_cobra_proxy(self):
 
@@ -111,20 +135,17 @@ class CobraBasicTest(unittest.TestCase):
     #def test_cobra_ssl(self):
     #def test_cobra_ssl_clientcert(self):
     def test_cobra_helpers(self):
+        try:
+            import msgpack
+        except ImportError:
+            self.skipTest('No msgpack installed!')
+
         portnum = itertools.count(60651)
 
         testobj = c_tests.TestObject()
 
         # test startCobraServer
-        port = None
-        daemon = None
-        while daemon is None:
-            try:
-                port = next(portnum)
-                daemon = cobra.startCobraServer(host="", port=port, sslca=None, sslcrt=None, sslkey=None, msgpack=True)
-
-            except Exception as e:
-                logger.warning("exception starting cobra server: %r", e)
+        port, daemon = _start_msgpack_cobra_server(portnum)
 
         objname = daemon.shareObject( testobj )
         tproxy = cobra.CobraProxy('cobra://localhost:%d/%s?msgpack=1' % (port, objname))

--- a/vtrace/platforms/linux.py
+++ b/vtrace/platforms/linux.py
@@ -514,6 +514,8 @@ class LinuxMixin(v_posix.PtraceMixin, v_posix.PosixMixin):
         attachThread() so callers in notifiers may call it (because
         it's also gotta be thread wrapped).
         """
+        self._validateThreadId(tid)
+
         if not attached:
             if v_posix.ptrace(PT_ATTACH, tid, 0, 0) != 0:
                 raise Exception("ERROR ptrace attach failed for thread %d" % tid)
@@ -524,6 +526,17 @@ class LinuxMixin(v_posix.PtraceMixin, v_posix.PosixMixin):
 
         self.setupPtraceOptions(tid)
         self.pthreads.append(tid)
+
+    def _validateThreadId(self, tid):
+        if tid <= 0:
+            raise vtrace.PlatformException('ERROR: Invalid threadid chosen: %d' % tid)
+
+    def _attachThreadFromEvent(self, tid):
+        if tid <= 0:
+            logger.warning('Ignoring invalid thread event tid: %d', tid)
+            return
+
+        self.attachThread(tid, attached=True)
 
     @v_base.threadwrap
     def setupPtraceOptions(self, tid):
@@ -602,7 +615,7 @@ class LinuxMixin(v_posix.PtraceMixin, v_posix.PosixMixin):
                 # Handle a new thread here!
                 newtid = self.getPtraceEvent()
                 # print('CLONE (new tid: %d)' % newtid)
-                self.attachThread(newtid, attached=True)
+                self._attachThreadFromEvent(newtid)
 
             elif sig == signal.SIGSTOP and tid != self.pid:
                 #print('OMG IM THE NEW THREAD! %d' % tid)
@@ -622,7 +635,7 @@ class LinuxMixin(v_posix.PtraceMixin, v_posix.PosixMixin):
                     newtid = self.getPtraceEvent(tid)
                     #print("WHY DID WE GET *ANOTHER* STOP?: %d" % tid)
                     #print('PTRACE EVENT: %d' % newtid)
-                    self.attachThread(newtid, attached=True)
+                    self._attachThreadFromEvent(newtid)
 
                 else: # on first attach...
                     self._stopped_hack = True

--- a/vtrace/platforms/linux.py
+++ b/vtrace/platforms/linux.py
@@ -532,11 +532,18 @@ class LinuxMixin(v_posix.PtraceMixin, v_posix.PosixMixin):
             raise vtrace.PlatformException('ERROR: Invalid threadid chosen: %d' % tid)
 
     def _attachThreadFromEvent(self, tid):
-        if tid <= 0:
-            logger.warning('Ignoring invalid thread event tid: %d', tid)
+        if tid is None or tid <= 0:
+            logger.warning('Ignoring invalid thread event tid: %r', tid)
             return
 
         self.attachThread(tid, attached=True)
+
+    def _getStoppedThreadFallback(self):
+        for tid in self._stopped_cache:
+            if tid > 0 and tid not in self.pthreads:
+                return tid
+
+        return None
 
     @v_base.threadwrap
     def setupPtraceOptions(self, tid):
@@ -633,6 +640,8 @@ class LinuxMixin(v_posix.PtraceMixin, v_posix.PosixMixin):
 
                 elif self._stopped_hack:
                     newtid = self.getPtraceEvent(tid)
+                    if newtid <= 0:
+                        newtid = self._getStoppedThreadFallback()
                     #print("WHY DID WE GET *ANOTHER* STOP?: %d" % tid)
                     #print('PTRACE EVENT: %d' % newtid)
                     self._attachThreadFromEvent(newtid)

--- a/vtrace/tests/testthread.py
+++ b/vtrace/tests/testthread.py
@@ -44,8 +44,10 @@ class LinuxThreadEventRegressionTest(unittest.TestCase):
             self.pid = 31337
             self.execing = False
             self._stopped_hack = True
+            self._stopped_cache = {}
             self.event_tid = event_tid
             self.attach_calls = []
+            self.pthreads = [self.pid]
 
         def getPtraceEvent(self, tid=None):
             return self.event_tid
@@ -55,6 +57,9 @@ class LinuxThreadEventRegressionTest(unittest.TestCase):
 
         def _attachThreadFromEvent(self, tid):
             return v_linux.LinuxMixin._attachThreadFromEvent(self, tid)
+
+        def _getStoppedThreadFallback(self):
+            return v_linux.LinuxMixin._getStoppedThreadFallback(self)
 
         def runAgain(self):
             pass
@@ -69,6 +74,15 @@ class LinuxThreadEventRegressionTest(unittest.TestCase):
         v_linux.LinuxMixin.platformProcessEvent(trace, (trace.pid, status))
 
         self.assertEqual(trace.attach_calls, [])
+
+    def test_stopped_hack_falls_back_to_cached_thread_id(self):
+        trace = self.FakeTrace(event_tid=0)
+        trace._stopped_cache[4242] = True
+        status = (signal.SIGSTOP << 8) | 0x7f
+
+        v_linux.LinuxMixin.platformProcessEvent(trace, (trace.pid, status))
+
+        self.assertEqual(trace.attach_calls, [(4242, True)])
 
     def test_stopped_hack_attaches_valid_thread_id(self):
         trace = self.FakeTrace(event_tid=4242)

--- a/vtrace/tests/testthread.py
+++ b/vtrace/tests/testthread.py
@@ -1,7 +1,10 @@
 import os
+import signal
+import unittest
 
 import vtrace
 import vtrace.tests as vt_tests
+import vtrace.platforms.linux as v_linux
 
 class ThreadNotifier(vtrace.Notifier):
 
@@ -31,3 +34,50 @@ class VtraceThreadTest(vt_tests.VtraceProcessTest):
 
         self.assertTrue(n.threadcreate)
         self.assertTrue(n.threadexit)
+
+
+class LinuxThreadEventRegressionTest(unittest.TestCase):
+
+    class FakeTrace:
+
+        def __init__(self, event_tid=0):
+            self.pid = 31337
+            self.execing = False
+            self._stopped_hack = True
+            self.event_tid = event_tid
+            self.attach_calls = []
+
+        def getPtraceEvent(self, tid=None):
+            return self.event_tid
+
+        def attachThread(self, tid, attached=False):
+            self.attach_calls.append((tid, attached))
+
+        def _attachThreadFromEvent(self, tid):
+            return v_linux.LinuxMixin._attachThreadFromEvent(self, tid)
+
+        def runAgain(self):
+            pass
+
+        def handlePosixSignal(self, sig):
+            raise AssertionError('unexpected signal handling path')
+
+    def test_stopped_hack_ignores_zero_thread_id(self):
+        trace = self.FakeTrace(event_tid=0)
+        status = (signal.SIGSTOP << 8) | 0x7f
+
+        v_linux.LinuxMixin.platformProcessEvent(trace, (trace.pid, status))
+
+        self.assertEqual(trace.attach_calls, [])
+
+    def test_stopped_hack_attaches_valid_thread_id(self):
+        trace = self.FakeTrace(event_tid=4242)
+        status = (signal.SIGSTOP << 8) | 0x7f
+
+        v_linux.LinuxMixin.platformProcessEvent(trace, (trace.pid, status))
+
+        self.assertEqual(trace.attach_calls, [(4242, True)])
+
+    def test_validate_thread_id_rejects_zero(self):
+        with self.assertRaises(vtrace.PlatformException):
+            v_linux.LinuxMixin._validateThreadId(self.FakeTrace(), 0)


### PR DESCRIPTION
Summary:
- guard Linux vtrace thread-event handling against invalid ptrace event tids
- recover stopped threads from `_stopped_cache` when ptrace event decoding returns invalid data
- bound the Cobra msgpack helper retry loop so repeated startup failures fail instead of hanging forever

Root cause:
- `vtrace.tests.testthread` could hang intermittently on Linux when a short-lived thread triggered a stop/event ordering race
- one observed failure mode was `attachThread(0)` reaching `waitpid(0, ...)`
- after guarding invalid tids, a second race remained: the tracer could see a real stopped thread first, then get an invalid ptrace event on the follow-up stop and fail to attach the already-stopped thread, leaving the trace in `RunForever`
- `cobra/tests/testbasic.py` also contained an unbounded retry loop around msgpack server startup, so repeated startup failures could hang the test indefinitely

Changes:
- add conservative validation around event-driven Linux thread attach paths
- add `_getStoppedThreadFallback()` to reuse a pending stopped thread id already recorded in `_stopped_cache`
- harden `_attachThreadFromEvent()` for invalid/None tids
- add regression coverage for the invalid-tid and stopped-cache fallback cases
- replace the unbounded Cobra helper retry loop with a bounded helper and add a regression test
- make `test_cobra_helpers` skip cleanly when `msgpack` is not installed locally

Testing:
- `python3 -m unittest vtrace.tests.testthread.VtraceThreadTest.test_vtrace_threads -v`
- `python3 -m unittest vtrace.tests.testthread.LinuxThreadEventRegressionTest -v`
- `python3 -m unittest cobra.tests.testbasic.CobraBasicTest.test_start_msgpack_cobra_server_retries_are_bounded -v`
- `python3 -m unittest vtrace.tests.testthread vtrace.tests.testbasic vtrace.tests.testwritemem -v`
- `python3 -m unittest vdb.tests.teststalker.VdbStalkerTest.test_vdb_stalker -v`

Notes:
- local environment is missing `pycparser` and `msgpack`, so some broader `vdb/tests` and msgpack-dependent Cobra tests cannot be fully verified here
- after these fixes, `VtraceThreadTest.test_vtrace_threads` passed repeatedly and the minimal short-lived-thread reproducer no longer hung
