### PR TITLE
Add real-time filtering to all VQ tree views

### DIFF
--- a/vivisect/qt/views.py
+++ b/vivisect/qt/views.py
@@ -4,6 +4,7 @@ import vivisect.base as viv_base
 import envi.qt.memory as e_q_memory
 import vivisect.qt.ctxmenu as v_q_ctxmenu
 
+from PyQt6 import QtCore
 from PyQt6.QtCore import QSortFilterProxyModel, QRegularExpression
 from PyQt6.QtGui import QActionGroup
 from PyQt6.QtWidgets import QMenu, QWidget, QLineEdit, QToolButton, QWidgetAction
@@ -30,7 +31,10 @@ class VivFilterModel(QSortFilterProxyModel):
     def __getattr__(self, name):
         # Delegate attribute lookups to the source model so
         # vivAddRow / append / vqDelRow etc. pass through transparently.
-        return getattr(self.sourceModel(), name)
+        src = self.sourceModel()
+        if src is None:
+            raise AttributeError(name)
+        return getattr(src, name)
 
 
 class VQFilterWidget(QLineEdit):

--- a/vivisect/qt/views.py
+++ b/vivisect/qt/views.py
@@ -1,16 +1,157 @@
 import vqt.tree as vq_tree
+import vqt.basics as vq_basics
 import vivisect.base as viv_base
 import envi.qt.memory as e_q_memory
 import vivisect.qt.ctxmenu as v_q_ctxmenu
 
-from PyQt6.QtWidgets import QMenu
+from PyQt6.QtCore import QSortFilterProxyModel, QRegularExpression
+from PyQt6.QtGui import QActionGroup
+from PyQt6.QtWidgets import QMenu, QWidget, QLineEdit, QToolButton, QWidgetAction
 
-from vqt.main import *
+from vqt.main import vqtevent
 from vqt.common import *
 from vivisect.const import *
 
 class VivNavModel(e_q_memory.EnviNavModel):
     pass
+
+
+class VivFilterModel(QSortFilterProxyModel):
+    """
+    A QSortFilterProxyModel configured for real-time full-column filtering
+    with transparent attribute delegation to the source model.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+        self.setDynamicSortFilter(True)
+        self.setFilterKeyColumn(-1)  # filter across all columns
+
+    def __getattr__(self, name):
+        # Delegate attribute lookups to the source model so
+        # vivAddRow / append / vqDelRow etc. pass through transparently.
+        return getattr(self.sourceModel(), name)
+
+
+class VQFilterWidget(QLineEdit):
+    """Line-edit filter bar with case-sensitivity toggle and pattern-type selection."""
+
+    filterChanged = QtCore.pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+        self.setClearButtonEnabled(True)
+        self.setPlaceholderText("Filter...")
+
+        self._caseSensitive = False
+        self._patternType = "fixed"
+
+        # ---- options menu ----
+        menu = QMenu(self)
+
+        caseAction = menu.addAction("Case Sensitive")
+        caseAction.setCheckable(True)
+        caseAction.toggled.connect(self._onCaseToggled)
+
+        menu.addSeparator()
+
+        patternGroup = QActionGroup(self)
+        patternGroup.setExclusive(True)
+
+        for label, ptype in [
+            ("Fixed String", "fixed"),
+            ("Regular Expression", "regex"),
+            ("Wildcard", "wildcard"),
+        ]:
+            action = menu.addAction(label)
+            action.setData(ptype)
+            action.setCheckable(True)
+            if ptype == "fixed":
+                action.setChecked(True)
+            patternGroup.addAction(action)
+
+        patternGroup.triggered.connect(self._onPatternChanged)
+
+        # ---- options button (hamburger style) ----
+        optionsBtn = QToolButton(self)
+        optionsBtn.setCursor(QtCore.Qt.CursorShape.ArrowCursor)
+        optionsBtn.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
+        optionsBtn.setStyleSheet("QToolButton { border: none; }")
+        optionsBtn.setArrowType(QtCore.Qt.ArrowType.DownArrow)
+        optionsBtn.setMenu(menu)
+        optionsBtn.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+
+        optionsAction = QWidgetAction(self)
+        optionsAction.setDefaultWidget(optionsBtn)
+        self.addAction(optionsAction, QLineEdit.ActionPosition.LeadingPosition)
+
+        self.textChanged.connect(self.filterChanged)
+
+    # -----------------------------------------------------------------
+    def _onCaseToggled(self, checked):
+        self._caseSensitive = checked
+        self.filterChanged.emit()
+
+    def _onPatternChanged(self, action):
+        self._patternType = action.data()
+        self.filterChanged.emit()
+
+    def getCaseSensitivity(self):
+        return (
+            QtCore.Qt.CaseSensitivity.CaseSensitive
+            if self._caseSensitive
+            else QtCore.Qt.CaseSensitivity.CaseInsensitive
+        )
+
+    def getPatternType(self):
+        return self._patternType
+
+
+class VivFilterView(QWidget):
+    """
+    Container widget that wraps a VQVivTreeView subclass (the **Part**)
+    together with a VQFilterWidget in a vertical layout.
+    Subclasses set *view_type* to their Part class.
+    """
+
+    view_type = None
+
+    def __init__(self, vw, vwqgui, *args, **kwargs):
+        super().__init__()
+
+        self.view = self.view_type(vw, vwqgui, *args, **kwargs)
+        self.ffilt = VQFilterWidget(self)
+
+        layout = vq_basics.VBox(self.view, self.ffilt)
+        self.setLayout(layout)
+
+        self.ffilt.filterChanged.connect(self._onFilterChanged)
+        self.setWindowTitle(self.view.window_title)
+
+    def _onFilterChanged(self):
+        text = self.ffilt.text()
+        if not text:
+            self.view.filterModel.setFilterRegularExpression(QRegularExpression())
+            return
+
+        ptype = self.ffilt.getPatternType()
+        cs = self.ffilt.getCaseSensitivity()
+
+        if ptype == "wildcard":
+            # * -> .*   ? -> .
+            pattern = QRegularExpression.escape(text).replace(r"\*", ".*").replace(r"\?", ".")
+            regex = QRegularExpression(pattern, cs)
+        elif ptype == "regex":
+            regex = QRegularExpression(text, cs)
+        else:
+            # Fixed string: escape for regex matching
+            regex = QRegularExpression(QRegularExpression.escape(text), cs)
+
+        self.view.filterModel.setFilterRegularExpression(regex)
+
+    def __getattr__(self, name):
+        return getattr(self.view, name)
+
 
 class VQVivTreeView(vq_tree.VQTreeView, viv_base.VivEventCore):
 
@@ -79,9 +220,16 @@ class VQVivTreeView(vq_tree.VQTreeView, viv_base.VivEventCore):
         if not pnode:
             return
 
-        idx = self.model().createIndex(pnode.row(), col, pnode)
-        # We are *not* the edit role...
-        self.model().setData(idx, val, role=None)
+        # When a proxy model is in use, access the source model directly
+        # to avoid index-mapping issues (the proxy's setData expects proxy
+        # indexes but we create source-model indexes here).
+        model = self.model()
+        src = getattr(model, 'sourceModel', None)
+        if src is not None:
+            model = src()
+
+        idx = model.createIndex(pnode.row(), col, pnode)
+        model.setData(idx, val, role=QtCore.Qt.ItemDataRole.DisplayRole)
 
     def vivGetData(self, va, col):
         pnode = self._viv_va_nodes.get(va)
@@ -95,8 +243,10 @@ class VQVivLocView(VQVivTreeView):
 
     def __init__(self, vw, vwqgui):
         VQVivTreeView.__init__(self, vw, vwqgui)
-        model = VivNavModel(self._viv_navcol, parent=self, columns=self.columns)
-        self.setModel(model)
+        self.navModel = VivNavModel(self._viv_navcol, parent=self, columns=self.columns)
+        self.filterModel = VivFilterModel()
+        self.filterModel.setSourceModel(self.navModel)
+        self.setModel(self.filterModel)
         self.vqLoad()
         self.vqSizeColumns()
 
@@ -118,7 +268,7 @@ class VQVivLocView(VQVivTreeView):
     def vivAddLocation(self, lva, lsize, ltype, linfo):
         raise NotImplementedError("LocationViews must override vivAddLocation")
 
-class VQVivStringsView(VQVivLocView):
+class VQVivStringsViewPart(VQVivLocView):
 
     columns = ('Address','String')
     loctypes = (LOC_STRING, LOC_UNI)
@@ -132,7 +282,7 @@ class VQVivStringsView(VQVivLocView):
             s = s.decode('utf-8', 'ignore')
         self.vivAddRow(lva, '0x%.8x' % lva, repr(s))
 
-class VQVivImportsView(VQVivLocView):
+class VQVivImportsViewPart(VQVivLocView):
 
     columns = ('Address', 'Library', 'Function')
     loctypes = (LOC_IMPORT,)
@@ -142,7 +292,7 @@ class VQVivImportsView(VQVivLocView):
         libname, funcname = linfo.split('.', 1)
         self.vivAddRow(lva, '0x%.8x' % lva, libname, funcname)
 
-class VQVivStructsView(VQVivLocView):
+class VQVivStructsViewPart(VQVivLocView):
     columns = ('Address', 'Structure', 'Loc Name')
     loctypes = (LOC_STRUCT,)
     window_title = 'Structures'
@@ -151,14 +301,17 @@ class VQVivStructsView(VQVivLocView):
         sym = self.vw.getSymByAddr(lva)
         self.vivAddRow(lva, '0x%.8x' % lva, linfo, str(sym))
 
-class VQVivExportsView(VQVivTreeView):
+class VQVivExportsViewPart(VQVivTreeView):
 
     window_title = 'Exports'
     columns = ('Address', 'File', 'Export')
 
     def __init__(self, vw, vwqgui):
         VQVivTreeView.__init__(self, vw, vwqgui)
-        self.setModel( VivNavModel(self._viv_navcol, self, columns=self.columns) )
+        self.navModel = VivNavModel(self._viv_navcol, self, columns=self.columns)
+        self.filterModel = VivFilterModel()
+        self.filterModel.setSourceModel(self.navModel)
+        self.setModel(self.filterModel)
         self.vqLoad()
         self.vqSizeColumns()
 
@@ -173,7 +326,7 @@ class VQVivExportsView(VQVivTreeView):
         va, etype, ename, fname = einfo
         self.vivAddExport(va, etype, ename, fname)
 
-class VQVivSegmentsView(VQVivTreeView):
+class VQVivSegmentsViewPart(VQVivTreeView):
 
     _viv_navcol = 2
     window_title = 'Segments'
@@ -181,7 +334,10 @@ class VQVivSegmentsView(VQVivTreeView):
 
     def __init__(self, vw, vwqgui):
         VQVivTreeView.__init__(self, vw, vwqgui)
-        self.setModel( VivNavModel(self._viv_navcol, self, columns=self.columns) )
+        self.navModel = VivNavModel(self._viv_navcol, self, columns=self.columns)
+        self.filterModel = VivFilterModel()
+        self.filterModel.setSourceModel(self.navModel)
+        self.setModel(self.filterModel)
         self.vqLoad()
         self.vqSizeColumns()
 
@@ -189,7 +345,8 @@ class VQVivSegmentsView(VQVivTreeView):
         for va, size, sname, fname in self.vw.getSegments():
             self.vivAddRow(va, fname, sname, '0x%.8x' % va, str(size))
 
-class VQVivFunctionsView(VQVivTreeView):
+
+class VQVivFunctionsViewPart(VQVivTreeView):
 
     _viv_navcol = 0
     window_title = 'Functions'
@@ -197,7 +354,10 @@ class VQVivFunctionsView(VQVivTreeView):
 
     def __init__(self, vw, vwqgui):
         VQVivTreeView.__init__(self, vw, vwqgui)
-        self.setModel(VivNavModel(self._viv_navcol, self, columns=self.columns))
+        self.navModel = VivNavModel(self._viv_navcol, self, columns=self.columns)
+        self.filterModel = VivFilterModel()
+        self.filterModel.setSourceModel(self.navModel)
+        self.setModel(self.filterModel)
         self.vqLoad()
         self.vqSizeColumns()
 
@@ -296,7 +456,7 @@ vaset_reprHandlers = {
     VASET_COMPLEX: reprComplex,
 }
 
-class VQVivVaSetView(VQVivTreeView):
+class VQVivVaSetViewPart(VQVivTreeView):
 
     _viv_navcol = 0
 
@@ -308,7 +468,10 @@ class VQVivVaSetView(VQVivTreeView):
 
         VQVivTreeView.__init__(self, vw, vwqgui)
 
-        self.setModel( VivNavModel(self._viv_navcol, self, columns=cols) )
+        self.navModel = VivNavModel(self._viv_navcol, self, columns=cols)
+        self.filterModel = VivFilterModel()
+        self.filterModel.setSourceModel(self.navModel)
+        self.setModel(self.filterModel)
         self.vqLoad()
         self.vqSizeColumns()
         self.setWindowTitle('Va Set: %s' % setname)
@@ -344,7 +507,7 @@ class VQVivVaSetView(VQVivTreeView):
 
         return row
 
-class VQXrefView(VQVivTreeView):
+class VQXrefViewPart(VQVivTreeView):
 
     _viv_navcol = 0
 
@@ -353,8 +516,10 @@ class VQXrefView(VQVivTreeView):
         self.window_title = title
 
         VQVivTreeView.__init__(self, vw, vwqgui)
-        model = VivNavModel(self._viv_navcol, self, columns=('Xref From', 'Xref Type', 'Xref Flags', 'Func Name'))
-        self.setModel(model)
+        self.navModel = VivNavModel(self._viv_navcol, self, columns=('Xref From', 'Xref Type', 'Xref Flags', 'Func Name'))
+        self.filterModel = VivFilterModel()
+        self.filterModel.setSourceModel(self.navModel)
+        self.setModel(self.filterModel)
 
         for fromva, tova, rtype, rflags in xrefs:
             fva = vw.getFunction(fromva)
@@ -365,7 +530,7 @@ class VQXrefView(VQVivTreeView):
 
         self.vqSizeColumns()
 
-class VQVivNamesView(VQVivTreeView):
+class VQVivNamesViewPart(VQVivTreeView):
 
     _viv_navcol = 0
     window_title = 'Workspace Names'
@@ -373,7 +538,10 @@ class VQVivNamesView(VQVivTreeView):
 
     def __init__(self, vw, vwqgui):
         VQVivTreeView.__init__(self, vw, vwqgui)
-        self.setModel(VivNavModel(self._viv_navcol, self, columns=self.columns))
+        self.navModel = VivNavModel(self._viv_navcol, self, columns=self.columns)
+        self.filterModel = VivFilterModel()
+        self.filterModel.setSourceModel(self.navModel)
+        self.setModel(self.filterModel)
         self.vqLoad()
         self.vqSizeColumns()
 
@@ -392,3 +560,43 @@ class VQVivNamesView(VQVivTreeView):
             self.vivAddRow(va, '0x%.8x' % va, name)
         else:
             self.vivSetData(va, 1, name)
+
+
+# =============================================================================
+# Filtered view wrappers  (keep original class names for layout restoration)
+# =============================================================================
+
+class VQVivFunctionsView(VivFilterView):
+    view_type = VQVivFunctionsViewPart
+
+
+class VQVivNamesView(VivFilterView):
+    view_type = VQVivNamesViewPart
+
+
+class VQVivExportsView(VivFilterView):
+    view_type = VQVivExportsViewPart
+
+
+class VQVivVaSetView(VivFilterView):
+    view_type = VQVivVaSetViewPart
+
+
+class VQXrefView(VivFilterView):
+    view_type = VQXrefViewPart
+
+
+class VQVivStringsView(VivFilterView):
+    view_type = VQVivStringsViewPart
+
+
+class VQVivImportsView(VivFilterView):
+    view_type = VQVivImportsViewPart
+
+
+class VQVivStructsView(VivFilterView):
+    view_type = VQVivStructsViewPart
+
+
+class VQVivSegmentsView(VivFilterView):
+    view_type = VQVivSegmentsViewPart

--- a/vivisect/qt/views.py
+++ b/vivisect/qt/views.py
@@ -14,7 +14,25 @@ from vqt.common import *
 from vivisect.const import *
 
 class VivNavModel(e_q_memory.EnviNavModel):
-    pass
+    """
+    Navigation model used as the source model for all VQ tree views.
+    Override append() to skip the internal VQTreeModel.sort() call,
+    since sorting is handled at the proxy level (VivFilterModel with
+    dynamicSortFilter=True).  Without this override the sort() inside
+    append() fires layoutAboutToBeChanged/layoutChanged on the source
+    model while the proxy is still processing the rowsInserted signal,
+    corrupting the view's internal item cache and causing a segfault.
+    """
+
+    def append(self, rowdata, parent=None):
+        if parent is None:
+            parent = self.rootnode
+        pidx = self.createIndex(parent.row(), 0, parent)
+        i = len(parent.children)
+        self.beginInsertRows(pidx, i, i)
+        node = parent.append(rowdata)
+        self.endInsertRows()
+        return node
 
 
 class VivFilterModel(QSortFilterProxyModel):
@@ -209,7 +227,12 @@ class VQVivTreeView(vq_tree.VQTreeView, viv_base.VivEventCore):
         menu.exec(event.globalPos())
 
     def vivAddRow(self, va, *row):
-        node = self.model().append(row)
+        # Access source model directly when a proxy is in use
+        model = self.model()
+        src = getattr(model, 'sourceModel', None)
+        if src is not None:
+            model = src()
+        node = model.append(row)
         node.va = va
         self._viv_va_nodes[va] = node
         return node
@@ -217,7 +240,11 @@ class VQVivTreeView(vq_tree.VQTreeView, viv_base.VivEventCore):
     def vivDelRow(self, va):
         node = self._viv_va_nodes.pop(va, None)
         if node:
-            self.model().vqDelRow(node)
+            model = self.model()
+            src = getattr(model, 'sourceModel', None)
+            if src is not None:
+                model = src()
+            model.vqDelRow(node)
 
     def vivSetData(self, va, col, val):
         '''

--- a/vivisect/qt/views.py
+++ b/vivisect/qt/views.py
@@ -89,16 +89,25 @@ class VQFilterWidget(QLineEdit):
         optionsAction.setDefaultWidget(optionsBtn)
         self.addAction(optionsAction, QLineEdit.ActionPosition.LeadingPosition)
 
-        self.textChanged.connect(self.filterChanged)
+        # ---- debounce timer: don't filter on every keystroke ----
+        self._debounceTimer = QtCore.QTimer(self)
+        self._debounceTimer.setSingleShot(True)
+        self._debounceTimer.setInterval(300)
+        self._debounceTimer.timeout.connect(self._emitFilterChanged)
+
+        self.textChanged.connect(self._debounceTimer.start)
+
+    def _emitFilterChanged(self):
+        self.filterChanged.emit()
 
     # -----------------------------------------------------------------
     def _onCaseToggled(self, checked):
         self._caseSensitive = checked
-        self.filterChanged.emit()
+        self._debounceTimer.start()
 
     def _onPatternChanged(self, action):
         self._patternType = action.data()
-        self.filterChanged.emit()
+        self._debounceTimer.start()
 
     def getCaseSensitivity(self):
         return (
@@ -465,9 +474,19 @@ class VQVivVaSetViewPart(VQVivTreeView):
     _viv_navcol = 0
 
     def __init__(self, vw, vwqgui, setname):
-        self._va_setname = setname
+        self._va_setname = setname or 'unknown'
 
-        setdef = vw.getVaSetDef( setname )
+        if setname is None:
+            VQVivTreeView.__init__(self, vw, vwqgui)
+            self.navModel = VivNavModel(self._viv_navcol, self, columns=('Address',))
+            self.filterModel = VivFilterModel()
+            self.filterModel.setSourceModel(self.navModel)
+            self.setModel(self.filterModel)
+            self.setWindowTitle('Va Set (unrestorable — open from Tools menu)')
+            self.window_title = 'Va Set (unrestorable)'
+            return
+
+        setdef = vw.getVaSetDef(setname)
         cols = [ cname for (cname,ctype) in setdef ]
 
         VQVivTreeView.__init__(self, vw, vwqgui)
@@ -479,6 +498,7 @@ class VQVivVaSetViewPart(VQVivTreeView):
         self.vqLoad()
         self.vqSizeColumns()
         self.setWindowTitle('Va Set: %s' % setname)
+        self.window_title = 'Va Set: %s' % setname
 
     def VWE_SETVASETROW(self, vw, event, einfo):
         setname, row = einfo

--- a/vqt/tree.py
+++ b/vqt/tree.py
@@ -14,13 +14,15 @@ class VQTreeItem(object):
         self.children.append(child)
         return child
 
-    def delete(self, rowdata):
-        idx = 0
-        for child in self.children:
-            if child.rowdata == rowdata:
+    def delete(self, child_item):
+        """
+        Remove and return *child_item* from this node's children by identity.
+        Returns None if *child_item* is not a child of this node.
+        """
+        for idx, child in enumerate(self.children):
+            if child is child_item:
                 return self.children.pop(idx)
-
-            idx += 1
+        return None
 
     def child(self, row):
         return self.children[row]
@@ -92,7 +94,15 @@ class VQTreeModel(QtCore.QAbstractItemModel):
         if parent is None:
             parent = self.rootnode
 
-        parent.delete(rowdata)
+        row = rowdata.row() if rowdata in parent.children else -1
+        if row < 0:
+            return None
+
+        pidx = self.createIndex(parent.row(), 0, parent)
+        self.beginRemoveRows(pidx, row, row)
+        node = parent.delete(rowdata)
+        self.endRemoveRows()
+        return node
 
     def sort(self, colnum, order=QtCore.Qt.SortOrder.AscendingOrder):
         self._sort_column = colnum
@@ -216,8 +226,17 @@ class VQTreeView(QTreeView):
             self.resizeColumnToContents(i)
 
     def setModel(self, model):
-        model.dataChanged.connect( self.dataChanged )
-        model.rowsInserted.connect( self.rowsInserted )
+        """
+        Set the view model and force ascending sort on column 0 for Qt6.
+
+        NOTE: QAbstractItemView.setModel() already connects the model's
+        dataChanged / rowsInserted / rowsRemoved / etc. signals to the
+        view's internal slots.  Do NOT reconnect them here — doing so
+        causes double-firing that corrupts the view's item cache
+        (especially when a QSortFilterProxyModel is in the signal chain,
+        where each source-row insertion already goes through two rounds
+        of signal translation).
+        """
         ret = QTreeView.setModel(self, model)
         # Qt6's header defaults to descending when sorting is enabled;
         # force ascending on column 0 to match user expectations.


### PR DESCRIPTION
## Summary

Adds real-time filtering to all vivisect VQ tree views (Functions, Segments, Strings, Imports, Exports, Names, VaSets, Xrefs, Structures).

## New Components

- **VivNavModel** — EnviNavModel subclass that overrides append() to skip internal sort(). Proxy handles sorting via dynamicSortFilter, preventing segfault from overlapping layoutAboutToBeChanged/rowsInserted signal cascades.
- **VivFilterModel** — QSortFilterProxyModel with dynamicSortFilter=True, cross-column filter (setFilterKeyColumn(-1)), transparent __getattr__ delegation to source model.
- **VQFilterWidget** — Filter bar with: real-time debounced filtering (300ms), case-sensitivity toggle, Fixed String / Regular Expression / Wildcard pattern types.
- **VivFilterView** — Container widget combining a Part (tree view) + VQFilterWidget in vertical layout.

## Refactoring
- All 9 view classes renamed to `XxxViewPart` (e.g. `VQVivFunctionsViewPart`)
- Original class names restored as `VivFilterView` subclasses — layout restoration via `vqBuildDockWidget` still works
- Mutators (`vivAddRow`, `vivDelRow`, `vivSetData`) access source model directly through `sourceModel()` to avoid proxy index-mapping segfaults
- VaSet view gains guard for `None` setname (dynamic/accidental instantiation)

## Bug Fixes

1. **Segfault #1** (proxy-filtered VQTree open): VivNavModel.append() strips sort from insertion — proxy handles sorting. Primary fix for the sort-cascade corruption of the proxy internal index cache.
2. **Segfault #2** (VQTree open): Removed redundant setModel signal connections — QAbstractItemView.setModel already connects dataChanged/rowsInserted internally.
3. **vqDelRow silent removal**: VQTreeModel.vqDelRow now properly emits beginRemoveRows/endRemoveRows signals (was silently removing rows).
4. **VQTreeItem.delete**: Changed from rowdata value comparison (always False in Python 3) to identity comparison.
5. **Qt6**: vivSetData uses explicit ItemDataRole.DisplayRole instead of role=None.

## Files
- `vivisect/qt/views.py` (+288/-62)
- `vqt/tree.py` (+25/-12)